### PR TITLE
Specify a specific LavinMQ version to bootstrap

### DIFF
--- a/AWS/env_template/benchmark.env
+++ b/AWS/env_template/benchmark.env
@@ -18,6 +18,10 @@ TF_VAR_tag_name="name-of-network-resources"
 TF_VAR_public_ssh_key="path-to-public-key"
 TF_VAR_ssh_key_name="name-your-key"
 
+# LavinMQ version, don't set to get latest version.
+# Example: "2.0.0"
+TF_VAR_lavinmq_version="lavinmq-version"
+
 # Benchmark server
 TF_VAR_benchmark_instance_type="instance-type"
 TF_VAR_benchmark_name="name-of-the-benchmark-server

--- a/AWS/instance/instance.tf
+++ b/AWS/instance/instance.tf
@@ -5,6 +5,7 @@ variable "tag_created_by" {}
 
 variable "subnet_id" {}
 variable "ssh_key_pair_name" {}
+variable "lavinmq_version" {}
 
 
 resource "aws_instance" "instance" {
@@ -13,7 +14,8 @@ resource "aws_instance" "instance" {
   subnet_id     = var.subnet_id
   key_name      = var.ssh_key_pair_name
 
-  user_data = file("${path.root}/scripts/bootstrap.sh")
+  user_data = templatefile("${path.root}/scripts/bootstrap.sh",
+    { LAVINMQ_VERSION = var.lavinmq_version})
 
   tags = {
     Name      = var.instance_name

--- a/AWS/main.tf
+++ b/AWS/main.tf
@@ -9,6 +9,7 @@ module "benchmark" {
   instance_type     = var.benchmark_instance_type
   instance_name     = var.benchmark_name
   ami_arch          = var.ami_arch
+  lavinmq_version   = var.lavinmq_version
   tag_created_by    = var.tag_created_by
   subnet_id         = aws_subnet.subnet.id
   ssh_key_pair_name = aws_key_pair.ssh_key.key_name
@@ -20,6 +21,7 @@ module "perftest" {
   instance_type     = var.perftest_instance_type
   instance_name     = var.perftest_name
   ami_arch          = var.ami_arch
+  lavinmq_version   = var.lavinmq_version
   tag_created_by    = var.tag_created_by
   subnet_id         = aws_subnet.subnet.id
   ssh_key_pair_name = aws_key_pair.ssh_key.key_name

--- a/AWS/scripts/bootstrap.sh
+++ b/AWS/scripts/bootstrap.sh
@@ -11,7 +11,10 @@ curl -fsSL https://packagecloud.io/cloudamqp/lavinmq/gpgkey | gpg --dearmor | su
 . /etc/os-release
 echo "deb [signed-by=/usr/share/keyrings/lavinmq.gpg] https://packagecloud.io/cloudamqp/lavinmq/$ID $VERSION_CODENAME main" | sudo tee /etc/apt/sources.list.d/lavinmq.list
 apt update
-apt install lavinmq -y
+if [ -n "${LAVINMQ_VERSION}" ]
+then sudo apt install "lavinmq=${LAVINMQ_VERSION}-1" -y
+else sudo apt install lavinmq -y
+fi
 
 lavinmqctl add_user perftest perftest
 lavinmqctl set_user_tags perftest administrator

--- a/AWS/variables.tf
+++ b/AWS/variables.tf
@@ -31,6 +31,11 @@ variable ssh_key_name {
   type = string
 }
 
+variable lavinmq_version {
+  type = string
+  default = ""
+}
+
 # Benchmark server
 variable benchmark_instance_type {
   type = string


### PR DESCRIPTION
### WHY are these changes introduced?

Benchmark servers will be created with latest LavinMQ version.

Reference: https://github.com/cloudamqp/lavinmq-benchmark/issues/5

### WHAT is this pull request doing?

Introduces a new variable to specify a specific LavinMQ version.
Default uses the latest version. 

### HOW can this pull request be tested?

Manuel tested to run benchmark with latest and older version.