### PR TITLE
Add support for multiple load generator servers

### DIFF
--- a/AWS/env_template/benchmark.env
+++ b/AWS/env_template/benchmark.env
@@ -29,14 +29,13 @@ TF_VAR_lavinmq_version="lavinmq-version"
 ## Broker server
 TF_VAR_broker_instance_type="instance-type"
 TF_VAR_broker_name="name-of-the-broker-server"
-### # Root disk volume size, don't set to use default 8 GiB size.
+### Root disk volume size, don't set to use default 8 GiB size.
 TF_VAR_broker_volume_size=10
 
 ## Load generator server
-### Adding more instance-types, will create additional load generator servers.
-### Exampel: TF_VAR_load_generator_instance_type=["instance-type", "instante-type"]
-### Will create 2 load generator servers, publishing and consuming messages from the broker.
-TF_VAR_load_generator_instance_type=["instance-type"]
+### Number of load generator servers, default set to 1.
+TF_VAR_load_generator_count=1
+TF_VAR_load_generator_instance_type="instance-type"
 TF_VAR_load_generator_name="name-of-the-load-generator-server"
 ### Root disk volume size, don't set to use default 8 GiB size.
 TF_VAR_load_generator_volume_size=10

--- a/AWS/scenarios/generic_throughtput/main.tf
+++ b/AWS/scenarios/generic_throughtput/main.tf
@@ -36,10 +36,10 @@ module "broker" {
 }
 
 module "load_generator" {
-  count = length(var.load_generator_instance_type)
+  count = var.load_generator_count
   source = "../../modules/instance"
 
-  instance_type     = var.load_generator_instance_type[count.index]
+  instance_type     = var.load_generator_instance_type
   instance_name     = format("%s_%s", var.load_generator_name, count.index)
   lavinmq_version   = var.lavinmq_version
   tag_created_by    = var.tag_created_by
@@ -53,7 +53,7 @@ module "load_generator" {
 }
 
 module "remote_execute" {
-  count = length(var.load_generator_instance_type)
+  count = var.load_generator_count
   source = "../../modules/remote_execute" 
 
   broker_public_dns         = module.broker.public_dns

--- a/AWS/scenarios/generic_throughtput/variables.tf
+++ b/AWS/scenarios/generic_throughtput/variables.tf
@@ -59,8 +59,12 @@ variable "broker_volume_size" {
 }
 
 ## Load generator server
+variable load_generator_count {
+  type = number
+  default = 1
+}
 variable load_generator_instance_type {
-  type = list(string)
+  type = string
 }
 
 variable load_generator_name {


### PR DESCRIPTION
### WHY are these changes introduced?

When running the benchmark, only one load generator server will be created.

### WHAT is this pull request doing?

Adds a new variable `TF_VAR_load_generator_count` to set number of 
load generator servers to be created. Default set to 1.

### HOW can this pull request be tested?

Set number of load generator servers to be created in `TF_VAR_load_generator_count`,
pick scenario and do a new benchmark run.

Results:
```
module.remote_execute[0].terraform_data.perftest (remote-exec): Summary:
module.remote_execute[0].terraform_data.perftest (remote-exec): Average publish rate: 189038.2 msgs/s
module.remote_execute[0].terraform_data.perftest (remote-exec): Average consume rate: 322452.9 msgs/s
module.remote_execute[1].terraform_data.perftest (remote-exec): Summary:
module.remote_execute[1].terraform_data.perftest (remote-exec): Average publish rate: 189143.3 msgs/s
module.remote_execute[1].terraform_data.perftest (remote-exec): Average consume rate: 54647.5 msgs/s
```