### PR TITLE
Make AMI data source as a stand alone module

### DIFF
--- a/AWS/modules/ami/ami.tf
+++ b/AWS/modules/ami/ami.tf
@@ -25,3 +25,7 @@ data "aws_ami" "ubuntu" {
 
   owners = ["099720109477"]
 }
+
+output "ami_id" {
+  value = data.aws_ami.ubuntu.id
+}

--- a/AWS/modules/instance/instance.tf
+++ b/AWS/modules/instance/instance.tf
@@ -1,4 +1,5 @@
 # input parameters of the module
+variable "ami_id" {}
 variable "instance_type" {}
 variable "instance_name" {}
 variable "tag_created_by" {}
@@ -10,7 +11,7 @@ variable "volume_size" {}
 
 
 resource "aws_instance" "instance" {
-  ami           = data.aws_ami.ubuntu.id
+  ami           = var.ami_id
   instance_type = var.instance_type
   subnet_id     = var.subnet_id
   key_name      = var.ssh_key_pair_name

--- a/AWS/scenarios/generic_throughtput/main.tf
+++ b/AWS/scenarios/generic_throughtput/main.tf
@@ -17,7 +17,14 @@ module "ssh" {
   public_ssh_key = var.public_ssh_key
 }
 
-# create servers
+
+module "ami" {
+  source = "../../modules/ami"
+
+  ami_arch         = var.ami_arch
+  ubuntu_code_name = var.ubuntu_code_name
+}
+
 module "broker" {
   source = "../../modules/instance"
 
@@ -28,8 +35,7 @@ module "broker" {
 
   subnet_id         = module.network.subnet_identifier
 
-  ami_arch          = var.ami_arch
-  ubuntu_code_name  = var.ubuntu_code_name
+  ami_id            = module.ami.ami_id
   volume_size       = var.broker_volume_size
   
   ssh_key_pair_name = var.ssh_key_name
@@ -45,8 +51,7 @@ module "load_generator" {
   tag_created_by    = var.tag_created_by
   subnet_id         = module.network.subnet_identifier
 
-  ami_arch          = var.ami_arch
-  ubuntu_code_name  = var.ubuntu_code_name
+  ami_id            = module.ami.ami_id
   volume_size       = var.load_generator_volume_size
   
   ssh_key_pair_name = var.ssh_key_name


### PR DESCRIPTION
### WHY are these changes introduced?

Each instance module used it's own AMI data source. Since all servers
uses the same Ubuntu version, they can all use the same data source.

### WHAT is this pull request doing?

Makes AMI data source as a stand alone module.
- Moves ami.tf into its own folder
- Updates variables and references 

### HOW can this pull request be tested?

Check state file after creating the servers and only one AMI
data source have been created.

