### PR TITLE
Use NVMe data disk if it's already present

### DIFF
--- a/scripts/install_lavinmq.sh
+++ b/scripts/install_lavinmq.sh
@@ -9,6 +9,13 @@ else
     REPO_NAME="lavinmq"
 fi
 
+mkdir -p /var/lib/lavinmq
+# Check if nvme1n1 SSD data disk is present
+if lsblk | grep -q nvme1n1; then
+  mkfs -t xfs /dev/nvme1n1
+  mount /dev/nvme1n1 /var/lib/lavinmq
+fi
+
 curl -fsSL https://packagecloud.io/cloudamqp/${REPO_NAME}/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/lavinmq.gpg > /dev/null
 . /etc/os-release
 echo "deb [signed-by=/usr/share/keyrings/lavinmq.gpg] https://packagecloud.io/cloudamqp/${REPO_NAME}/$ID $VERSION_CODENAME main" | sudo tee /etc/apt/sources.list.d/lavinmq.list > /dev/null


### PR DESCRIPTION
### WHY are these changes introduced?

High storage performance instance types, e.g. i7i.large, i8g.large also adds NVMe data disk.

Reference: https://github.com/cloudamqp/lavinmq-benchmark/issues/13

### WHAT is this pull request doing?

Before installing LavinMQ, find and mount NVMe data disk if it's present.

### HOW was this pull request tested?

New benchmark against broker with i8g.large and load generator with c8g.large.
Checked so broker got the data disk mounted at `/var/lib/lavinmq` while load generator didn't.

