### PR TITLE
Support multiple runs per combination

### DIFF
--- a/scenarios/aws/multiple_run_latency/README.md
+++ b/scenarios/aws/multiple_run_latency/README.md
@@ -76,9 +76,10 @@ TF_VAR_load_generator_volume_size = 8                                       # Ro
 TF_VAR_lavinmq_version = ""                                                 # Empty = latest, or specify version
 
 # Test configuration
-TF_VAR_message_sizes = [16, 64, 256, 512, 1024]                            # Message sizes in bytes
+TF_VAR_message_sizes = [16, 64, 256, 512, 1024, 4096, 16384, 65536]        # Message sizes in bytes
 TF_VAR_rate_limits = [10, 100, 1000, 10000, 50000, 100000, 200000, 500000] # Rate limits in msgs/s
-TF_VAR_test_duration = 120                                                  # Duration of each test in seconds
+TF_VAR_test_duration = 120                                                 # Duration of each test in seconds
+TF_VAR_num_runs = 3                                                        # Number of runs per combination, default 1
 ```
 
 ## Usage

--- a/scenarios/aws/multiple_run_latency/README.md
+++ b/scenarios/aws/multiple_run_latency/README.md
@@ -80,6 +80,12 @@ TF_VAR_message_sizes = [16, 64, 256, 512, 1024, 4096, 16384, 65536]        # Mes
 TF_VAR_rate_limits = [10, 100, 1000, 10000, 50000, 100000, 200000, 500000] # Rate limits in msgs/s
 TF_VAR_test_duration = 120                                                 # Duration of each test in seconds
 TF_VAR_num_runs = 3                                                        # Number of runs per combination, default 1
+
+# Optional: per-message-size rate limit overrides.
+# Sizes not listed fall back to TF_VAR_rate_limits.
+# This ensures no rate limit exceeds the instance's measured max throughput,
+# keeping latency results meaningful and comparable across instance types.
+TF_VAR_per_size_rate_limits = {"16":[10,100,1000,10000,50000,100000,250000,500000],"64":[10,100,1000,10000,50000,100000,250000,450000],"256":[10,100,1000,10000,50000,100000,350000],"512":[10,100,1000,10000,50000,100000,150000],"1024":[10,100,1000,10000,25000,50000,80000],"4096":[10,100,1000,5000,10000,20000],"16384":[10,100,500,1000,2000,5000],"65536":[10,100,500,1000]}
 ```
 
 ## Usage

--- a/scenarios/aws/multiple_run_latency/main.tf
+++ b/scenarios/aws/multiple_run_latency/main.tf
@@ -82,13 +82,14 @@ resource "terraform_data" "multiple_latency_tests" {
     agent = true
   }
 
-  # Trigger replacement when message sizes, rate limits, test duration, broker instance type, or lavinmq version changes
+  # Trigger replacement when message sizes, rate limits, test duration, broker instance type, lavinmq version, or num_runs changes
   triggers_replace = [
     join(",", var.message_sizes),
     join(",", var.rate_limits),
     var.test_duration,
     var.broker_instance_type,
-    var.lavinmq_version
+    var.lavinmq_version,
+    var.num_runs
   ]
 
   # Upload the test script
@@ -101,12 +102,13 @@ resource "terraform_data" "multiple_latency_tests" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /home/ubuntu/run_multiple_latency_tests.sh",
-      format("/home/ubuntu/run_multiple_latency_tests.sh %s %s %s %s %s",
+      format("/home/ubuntu/run_multiple_latency_tests.sh %s %s %s %s %s %s",
         module.broker.private_ip,
         join(",", var.message_sizes),
         join(",", var.rate_limits),
         var.test_duration,
-        var.broker_instance_type
+        var.broker_instance_type,
+        var.num_runs
       )
     ]
   }

--- a/scenarios/aws/multiple_run_latency/main.tf
+++ b/scenarios/aws/multiple_run_latency/main.tf
@@ -86,6 +86,7 @@ resource "terraform_data" "multiple_latency_tests" {
   triggers_replace = [
     join(",", var.message_sizes),
     join(",", var.rate_limits),
+    join("|", [for s, r in var.per_size_rate_limits : "${s}:${join(",", r)}"]),
     var.test_duration,
     var.broker_instance_type,
     var.lavinmq_version,
@@ -102,13 +103,14 @@ resource "terraform_data" "multiple_latency_tests" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /home/ubuntu/run_multiple_latency_tests.sh",
-      format("/home/ubuntu/run_multiple_latency_tests.sh %s %s %s %s %s %s",
+      format("/home/ubuntu/run_multiple_latency_tests.sh %s %s %s %s %s %s '%s'",
         module.broker.private_ip,
         join(",", var.message_sizes),
         join(",", var.rate_limits),
         var.test_duration,
         var.broker_instance_type,
-        var.num_runs
+        var.num_runs,
+        join("|", [for s, r in var.per_size_rate_limits : "${s}:${join(",", r)}"])
       )
     ]
   }

--- a/scenarios/aws/multiple_run_latency/variables.tf
+++ b/scenarios/aws/multiple_run_latency/variables.tf
@@ -94,3 +94,9 @@ variable "test_duration" {
   type        = number
   default     = 120
 }
+
+variable "num_runs" {
+  description = "Number of times to repeat each size/rate combination (results are averaged in the summary)"
+  type        = number
+  default     = 1
+}

--- a/scenarios/aws/multiple_run_latency/variables.tf
+++ b/scenarios/aws/multiple_run_latency/variables.tf
@@ -100,3 +100,9 @@ variable "num_runs" {
   type        = number
   default     = 1
 }
+
+variable "per_size_rate_limits" {
+  description = "Per-message-size rate limits. Overrides rate_limits for each specified size. Key is message size in bytes (as string), value is list of rate limits in msgs/s."
+  type        = map(list(number))
+  default     = {}
+}

--- a/scenarios/aws/multiple_run_throughput/README.md
+++ b/scenarios/aws/multiple_run_throughput/README.md
@@ -77,7 +77,7 @@ TF_VAR_lavinmq_version = ""            # Empty = latest, or specify version
 # Test configuration
 TF_VAR_message_sizes = [16, 64, 256, 512, 1024, 4096, 16384, 65536]  # Message sizes in bytes
 TF_VAR_test_duration = 120                                           # Duration of each test in seconds
-TF_VAR_num_runs=1                                                    # Number of runs
+TF_VAR_num_runs = 3                                                  # Number of runs per combination, default 1
 ```
 
 ## Usage

--- a/scenarios/aws/multiple_run_throughput/README.md
+++ b/scenarios/aws/multiple_run_throughput/README.md
@@ -66,17 +66,18 @@ TF_VAR_load_generator_name="Benchmark-loadgen"
 
 ```bash
 # Infrastructure
-TF_VAR_ami_arch = "arm64"                         # or "amd64"
-TF_VAR_ubuntu_code_name = "noble"                 # Ubuntu version
+TF_VAR_ami_arch = "arm64"           # or "amd64"
+TF_VAR_ubuntu_code_name = "noble"   # Ubuntu version
 
 # Benchmark server
-TF_VAR_broker_volume_size = 8                     # Root disk size in GB
-TF_VAR_load_generator_volume_size = 8             # Root disk size in GB
-TF_VAR_lavinmq_version = ""                       # Empty = latest, or specify version
+TF_VAR_broker_volume_size = 8          # Root disk size in GB
+TF_VAR_load_generator_volume_size = 8  # Root disk size in GB
+TF_VAR_lavinmq_version = ""            # Empty = latest, or specify version
 
 # Test configuration
-TF_VAR_message_sizes = [16, 64, 256, 512, 1024]   # Message sizes in bytes
-TF_VAR_test_duration = 120                        # Duration of each test in seconds
+TF_VAR_message_sizes = [16, 64, 256, 512, 1024, 4096, 16384, 65536]  # Message sizes in bytes
+TF_VAR_test_duration = 120                                           # Duration of each test in seconds
+TF_VAR_num_runs=1                                                    # Number of runs
 ```
 
 ## Usage

--- a/scenarios/aws/multiple_run_throughput/main.tf
+++ b/scenarios/aws/multiple_run_throughput/main.tf
@@ -82,12 +82,13 @@ resource "terraform_data" "multiple_throughput_tests" {
     agent = true
   }
 
-  # Trigger replacement when message sizes, test duration, broker instance type, or lavinmq version changes
+  # Trigger replacement when message sizes, test duration, broker instance type, lavinmq version, or num_runs changes
   triggers_replace = [
     join(",", var.message_sizes),
     var.test_duration,
     var.broker_instance_type,
-    var.lavinmq_version
+    var.lavinmq_version,
+    var.num_runs
   ]
 
   # Upload the test script
@@ -100,11 +101,12 @@ resource "terraform_data" "multiple_throughput_tests" {
   provisioner "remote-exec" {
     inline = [
       "chmod +x /home/ubuntu/run_multiple_throughput_tests.sh",
-      format("/home/ubuntu/run_multiple_throughput_tests.sh %s %s %s %s",
+      format("/home/ubuntu/run_multiple_throughput_tests.sh %s %s %s %s %s",
         module.broker.private_ip,
         join(",", var.message_sizes),
         var.test_duration,
-        var.broker_instance_type
+        var.broker_instance_type,
+        var.num_runs
       )
     ]
   }

--- a/scenarios/aws/multiple_run_throughput/variables.tf
+++ b/scenarios/aws/multiple_run_throughput/variables.tf
@@ -88,3 +88,9 @@ variable "test_duration" {
   type        = number
   default     = 120
 }
+
+variable "num_runs" {
+  description = "Number of times to repeat each size test (results are averaged in the summary)"
+  type        = number
+  default     = 1
+}

--- a/scripts/run_multiple_latency_tests.sh
+++ b/scripts/run_multiple_latency_tests.sh
@@ -217,7 +217,7 @@ echo "Generating markdown summary..."
     else
       # Per-run tables
       for RUN in $(seq 1 "$NUM_RUNS"); do
-        echo "### Run $RUN of $NUM_RUNS"
+        echo "### Run $RUN of $NUM_RUNS ($SIZE)"
         echo ""
         echo "| Rate Limit |     Min |  Median |     P75 |     P95 |      P99 | Pub. Rate |  Pub. BW |  Con. BW |"
         echo "|-----------:|--------:|--------:|--------:|--------:|---------:|----------:|---------:|---------:|"
@@ -234,7 +234,7 @@ echo "Generating markdown summary..."
       done
 
       # Summary table (median across runs per rate — robust against single-run spikes)
-      echo "### Summary ($NUM_RUNS runs)"
+      echo "### Summary ($NUM_RUNS runs, $SIZE)"
       echo ""
       echo "| Rate Limit |     Min |  Median |     P75 |     P95 |      P99 | Pub. Rate |  Pub. BW |  Con. BW |"
       echo "|-----------:|--------:|--------:|--------:|--------:|---------:|----------:|---------:|---------:|"

--- a/scripts/run_multiple_latency_tests.sh
+++ b/scripts/run_multiple_latency_tests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Script to run multiple latency tests with different message sizes and rate limits
-# Usage: ./run_multiple_latency_tests.sh <broker_ip> [size1,size2,...] [rate1,rate2,...] [duration] [broker_instance_type] [num_runs]
+# Usage: ./run_multiple_latency_tests.sh <broker_ip> [size1,size2,...] [rate1,rate2,...] [duration] [broker_instance_type] [num_runs] [per_size_rate_limits]
+#   per_size_rate_limits format: "16:10,100,500000|64:10,100,450000" (size:rates pairs separated by |)
 
 set -e  # Exit on error
 
@@ -19,13 +20,14 @@ RATE_LIMITS="${3:-10,100,1000,10000,50000,100000,200000,500000}"  # Default rate
 DURATION="${4:-120}"  # Default duration 120 seconds if not provided
 BROKER_INSTANCE_TYPE="${5:-unknown}"  # Broker instance type for reporting
 NUM_RUNS="${6:-${BENCHMARK_NUM_RUNS:-1}}"  # Number of runs per combination, default 1
+PER_SIZE_RATE_LIMITS="${7:-}"              # Optional per-size rate limits, format: "size1:r1,r2|size2:r1,r2"
 OUTPUT_FILE="/home/ubuntu/latency_results.md"
 TEMP_DIR="/tmp/latency_test_$$"
 QUEUE_NAME="perf-test"
 
 if [ -z "$BROKER_IP" ]; then
   echo "Error: Broker IP not provided"
-  echo "Usage: $0 <broker_ip> [size1,size2,...] [rate1,rate2,...] [duration] [broker_instance_type] [num_runs]"
+  echo "Usage: $0 <broker_ip> [size1,size2,...] [rate1,rate2,...] [duration] [broker_instance_type] [num_runs] [per_size_rate_limits]"
   exit 1
 fi
 
@@ -54,6 +56,7 @@ echo "Broker Instance Type: $BROKER_INSTANCE_TYPE"
 echo "LavinMQ Version: $LAVINMQ_VERSION"
 echo "Message Sizes: $SIZES"
 echo "Rate Limits: $RATE_LIMITS msgs/s"
+echo "Per-Size Rate Limits: ${PER_SIZE_RATE_LIMITS:-(using global rate limits)}"
 echo "Test Duration: $DURATION seconds"
 echo "Number of Runs: $NUM_RUNS"
 echo "Output File: $OUTPUT_FILE"
@@ -63,6 +66,15 @@ echo ""
 # Convert comma-separated values to arrays
 IFS=',' read -ra SIZE_ARRAY <<< "$SIZES"
 IFS=',' read -ra RATE_ARRAY <<< "$RATE_LIMITS"
+
+# Parse per-size rate limits into associative array (format: "16:10,100,500000|64:10,100,450000")
+declare -A SIZE_RATE_MAP
+if [ -n "$PER_SIZE_RATE_LIMITS" ]; then
+  IFS='|' read -ra SIZE_RATE_PAIRS <<< "$PER_SIZE_RATE_LIMITS"
+  for PAIR in "${SIZE_RATE_PAIRS[@]}"; do
+    SIZE_RATE_MAP["${PAIR%%:*}"]="${PAIR#*:}"
+  done
+fi
 
 # Initialize CSV files for each size
 for SIZE in "${SIZE_ARRAY[@]}"; do
@@ -84,8 +96,12 @@ for RUN in $(seq 1 "$NUM_RUNS"); do
 
     SIZE_CSV="$TEMP_DIR/size_${SIZE}.csv"
 
+    # Determine rate limits for this size (per-size override or global fallback)
+    RATES_STR="${SIZE_RATE_MAP[$SIZE]:-$RATE_LIMITS}"
+    IFS=',' read -ra RATES_THIS_SIZE <<< "$RATES_STR"
+
     # Run test for each rate limit
-    for RATE in "${RATE_ARRAY[@]}"; do
+    for RATE in "${RATES_THIS_SIZE[@]}"; do
       echo "--------------------------------------"
       echo "Run $RUN/$NUM_RUNS — size: $SIZE bytes, rate: $RATE msgs/s"
       echo "--------------------------------------"
@@ -183,6 +199,13 @@ echo "Generating markdown summary..."
   echo "- Runs per combination: $NUM_RUNS"
   echo "- Message sizes: $SIZES bytes"
   echo "- Rate limits: $RATE_LIMITS msgs/s"
+  if [ -n "$PER_SIZE_RATE_LIMITS" ]; then
+    echo "- Per-size rate limits override:"
+    IFS='|' read -ra _PAIRS <<< "$PER_SIZE_RATE_LIMITS"
+    for _PAIR in "${_PAIRS[@]}"; do
+      echo "  - ${_PAIR%%:*} bytes: ${_PAIR#*:} msgs/s"
+    done
+  fi
   echo "- Queue: $QUEUE_NAME"
   echo "- Latency measurement: Enabled (\`--measure-latency\`)"
   echo ""
@@ -239,7 +262,9 @@ echo "Generating markdown summary..."
       echo "| Rate Limit |     Min |  Median |     P75 |     P95 |      P99 | Pub. Rate |  Pub. BW |  Con. BW |"
       echo "|-----------:|--------:|--------:|--------:|--------:|---------:|----------:|---------:|---------:|"
 
-      for RATE in "${RATE_ARRAY[@]}"; do
+      RATES_STR="${SIZE_RATE_MAP[$SIZE]:-$RATE_LIMITS}"
+      IFS=',' read -ra RATES_THIS_SIZE <<< "$RATES_STR"
+      for RATE in "${RATES_THIS_SIZE[@]}"; do
         MED_MIN=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$3} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
         MED_MEDIAN=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$4} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
         MED_P75=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$5} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")

--- a/scripts/run_multiple_latency_tests.sh
+++ b/scripts/run_multiple_latency_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script to run multiple latency tests with different message sizes and rate limits
-# Usage: ./run_multiple_latency_tests.sh <broker_ip> [size1,size2,...] [rate1,rate2,...] [duration] [broker_instance_type]
+# Usage: ./run_multiple_latency_tests.sh <broker_ip> [size1,size2,...] [rate1,rate2,...] [duration] [broker_instance_type] [num_runs]
 
 set -e  # Exit on error
 
@@ -18,13 +18,14 @@ SIZES="${2:-16,64,256,512,1024}"  # Default sizes if not provided
 RATE_LIMITS="${3:-10,100,1000,10000,50000,100000,200000,500000}"  # Default rate limits
 DURATION="${4:-120}"  # Default duration 120 seconds if not provided
 BROKER_INSTANCE_TYPE="${5:-unknown}"  # Broker instance type for reporting
+NUM_RUNS="${6:-${BENCHMARK_NUM_RUNS:-1}}"  # Number of runs per combination, default 1
 OUTPUT_FILE="/home/ubuntu/latency_results.md"
 TEMP_DIR="/tmp/latency_test_$$"
 QUEUE_NAME="perf-test"
 
 if [ -z "$BROKER_IP" ]; then
   echo "Error: Broker IP not provided"
-  echo "Usage: $0 <broker_ip> [size1,size2,...] [rate1,rate2,...] [duration] [broker_instance_type]"
+  echo "Usage: $0 <broker_ip> [size1,size2,...] [rate1,rate2,...] [duration] [broker_instance_type] [num_runs]"
   exit 1
 fi
 
@@ -54,6 +55,7 @@ echo "LavinMQ Version: $LAVINMQ_VERSION"
 echo "Message Sizes: $SIZES"
 echo "Rate Limits: $RATE_LIMITS msgs/s"
 echo "Test Duration: $DURATION seconds"
+echo "Number of Runs: $NUM_RUNS"
 echo "Output File: $OUTPUT_FILE"
 echo "=========================================="
 echo ""
@@ -62,93 +64,104 @@ echo ""
 IFS=',' read -ra SIZE_ARRAY <<< "$SIZES"
 IFS=',' read -ra RATE_ARRAY <<< "$RATE_LIMITS"
 
-# Run tests for each size
+# Initialize CSV files for each size
 for SIZE in "${SIZE_ARRAY[@]}"; do
-  echo "=========================================="
-  echo "Testing message size: $SIZE bytes"
-  echo "=========================================="
-  
-  # Initialize CSV for this size
   SIZE_CSV="$TEMP_DIR/size_${SIZE}.csv"
-  echo "RateLimit,Min,Median,P75,P95,P99,PubRate,PubBW,ConBW" > "$SIZE_CSV"
-  
-  # Run test for each rate limit
-  for RATE in "${RATE_ARRAY[@]}"; do
-    echo "--------------------------------------"
-    echo "Testing with rate limit: $RATE msgs/s"
-    echo "--------------------------------------"
-    
-    # Purge the queue before test using HTTP API
-    echo "Purging queue '$QUEUE_NAME' via HTTP API..."
-    PURGE_RESPONSE=$(curl -s -w "\n%{http_code}" --request DELETE \
-      --url "http://$BROKER_IP:15672/api/queues/%2F/$QUEUE_NAME/contents" \
-      --header 'Accept: application/json' \
-      --header 'Authorization: Basic cGVyZnRlc3Q6cGVyZnRlc3Q=' 2>&1)
-    
-    HTTP_CODE=$(echo "$PURGE_RESPONSE" | tail -n1)
-    if [ "$HTTP_CODE" = "204" ] || [ "$HTTP_CODE" = "200" ]; then
-      echo "Queue purged successfully"
-    else
-      echo "Warning: Queue purge returned HTTP $HTTP_CODE (queue may not exist yet or already empty)"
-    fi
-    
-    # Run the latency test
-    echo "Running latency test (size=$SIZE, rate=$RATE, duration=$DURATION seconds)..."
-    TEST_OUTPUT=$(lavinmqperf throughput -z "$DURATION" -x 1 -y 1 -s "$SIZE" -r "$RATE" --measure-latency \
-      --uri="amqp://perftest:perftest@$BROKER_IP?tcp_nodelay=true" 2>&1)
-    
-    # Display the output
-    echo "$TEST_OUTPUT"
-    
-    # Extract only the Summary section (everything after "Summary:")
-    SUMMARY=$(echo "$TEST_OUTPUT" | sed -n '/^Summary:/,$p')
-    
-    # Parse latency results from Summary section (already in milliseconds)
-    MIN_MS=$(echo "$SUMMARY" | grep -E "^\s+min:\s+" | awk '{print $2}')
-    MEDIAN_MS=$(echo "$SUMMARY" | grep -E "^\s+median:\s+" | awk '{print $2}')
-    P75_MS=$(echo "$SUMMARY" | grep -E "^\s+75th:\s+" | awk '{print $2}')
-    P95_MS=$(echo "$SUMMARY" | grep -E "^\s+95th:\s+" | awk '{print $2}')
-    P99_MS=$(echo "$SUMMARY" | grep -E "^\s+99th:\s+" | awk '{print $2}')
-    
-    # Parse average throughput from Summary section for bandwidth calculation
-    PUB_RATE=$(echo "$SUMMARY" | grep "Average publish rate:" | awk '{print $4}')
-    CON_RATE=$(echo "$SUMMARY" | grep "Average consume rate:" | awk '{print $4}')
-    
-    if [ -z "$MIN_MS" ] || [ -z "$MEDIAN_MS" ] || [ -z "$PUB_RATE" ]; then
-      echo "Error: Failed to parse test results for size $SIZE, rate $RATE"
-      echo "MIN_MS=$MIN_MS, MEDIAN_MS=$MEDIAN_MS, PUB_RATE=$PUB_RATE"
-      exit 1
-    fi
-    
-    # Format latency values to 2 decimal places
-    MIN_MS=$(printf "%.2f" "$MIN_MS")
-    MEDIAN_MS=$(printf "%.2f" "$MEDIAN_MS")
-    P75_MS=$(printf "%.2f" "$P75_MS")
-    P95_MS=$(printf "%.2f" "$P95_MS")
-    P99_MS=$(printf "%.2f" "$P99_MS")
+  echo "Run,RateLimit,Min,Median,P75,P95,P99,PubRate,PubBW,ConBW" > "$SIZE_CSV"
+done
 
-    # Calculate bandwidth in MiB/s and format to 2 decimal places
-    PUB_BW=$(echo "scale=2; ($SIZE * $PUB_RATE) / (1024 * 1024)" | bc)
-    CON_BW=$(echo "scale=2; ($SIZE * $CON_RATE) / (1024 * 1024)" | bc)
-    
-    # Ensure leading zero for values < 1.0
-    [[ "$PUB_BW" =~ ^\. ]] && PUB_BW="0$PUB_BW"
-    [[ "$CON_BW" =~ ^\. ]] && CON_BW="0$CON_BW"
-
-    # Format bandwidth to exactly 2 decimal places
-    PUB_BW=$(printf "%.2f" "$PUB_BW")
-    CON_BW=$(printf "%.2f" "$CON_BW")
-    
-    echo "Results: Latency min/median/p75/p95/p99: ${MIN_MS}/${MEDIAN_MS}/${P75_MS}/${P95_MS}/${P99_MS} ms"
-    echo "         Publish rate: $PUB_RATE msgs/s"
-    echo "         Bandwidth: Publish=$PUB_BW MiB/s, Consume=$CON_BW MiB/s"
-    echo ""
-    
-    # Append to CSV
-    echo "$RATE,$MIN_MS,$MEDIAN_MS,$P75_MS,$P95_MS,$P99_MS,$PUB_RATE,$PUB_BW,$CON_BW" >> "$SIZE_CSV"
-  done
-  
+# Run tests: outer loop = runs, middle = sizes, inner = rates
+for RUN in $(seq 1 "$NUM_RUNS"); do
+  echo "=========================================="
+  echo "Run $RUN of $NUM_RUNS"
+  echo "=========================================="
   echo ""
+
+  for SIZE in "${SIZE_ARRAY[@]}"; do
+    echo "=========================================="
+    echo "Run $RUN/$NUM_RUNS — message size: $SIZE bytes"
+    echo "=========================================="
+
+    SIZE_CSV="$TEMP_DIR/size_${SIZE}.csv"
+
+    # Run test for each rate limit
+    for RATE in "${RATE_ARRAY[@]}"; do
+      echo "--------------------------------------"
+      echo "Run $RUN/$NUM_RUNS — size: $SIZE bytes, rate: $RATE msgs/s"
+      echo "--------------------------------------"
+      
+      # Purge the queue before test using HTTP API
+      echo "Purging queue '$QUEUE_NAME' via HTTP API..."
+      PURGE_RESPONSE=$(curl -s -w "\n%{http_code}" --request DELETE \
+        --url "http://$BROKER_IP:15672/api/queues/%2F/$QUEUE_NAME/contents" \
+        --header 'Accept: application/json' \
+        --header 'Authorization: Basic cGVyZnRlc3Q6cGVyZnRlc3Q=' 2>&1)
+      
+      HTTP_CODE=$(echo "$PURGE_RESPONSE" | tail -n1)
+      if [ "$HTTP_CODE" = "204" ] || [ "$HTTP_CODE" = "200" ]; then
+        echo "Queue purged successfully"
+      else
+        echo "Warning: Queue purge returned HTTP $HTTP_CODE (queue may not exist yet or already empty)"
+      fi
+      
+      # Run the latency test
+      echo "Running latency test (size=$SIZE, rate=$RATE, duration=$DURATION seconds)..."
+      TEST_OUTPUT=$(lavinmqperf throughput -z "$DURATION" -x 1 -y 1 -s "$SIZE" -r "$RATE" --measure-latency \
+        --uri="amqp://perftest:perftest@$BROKER_IP?tcp_nodelay=true" 2>&1)
+      
+      # Display the output
+      echo "$TEST_OUTPUT"
+      
+      # Extract only the Summary section (everything after "Summary:")
+      SUMMARY=$(echo "$TEST_OUTPUT" | sed -n '/^Summary:/,$p')
+      
+      # Parse latency results from Summary section (already in milliseconds)
+      MIN_MS=$(echo "$SUMMARY" | grep -E "^\s+min:\s+" | awk '{print $2}')
+      MEDIAN_MS=$(echo "$SUMMARY" | grep -E "^\s+median:\s+" | awk '{print $2}')
+      P75_MS=$(echo "$SUMMARY" | grep -E "^\s+75th:\s+" | awk '{print $2}')
+      P95_MS=$(echo "$SUMMARY" | grep -E "^\s+95th:\s+" | awk '{print $2}')
+      P99_MS=$(echo "$SUMMARY" | grep -E "^\s+99th:\s+" | awk '{print $2}')
+      
+      # Parse average throughput from Summary section for bandwidth calculation
+      PUB_RATE=$(echo "$SUMMARY" | grep "Average publish rate:" | awk '{print $4}')
+      CON_RATE=$(echo "$SUMMARY" | grep "Average consume rate:" | awk '{print $4}')
+      
+      if [ -z "$MIN_MS" ] || [ -z "$MEDIAN_MS" ] || [ -z "$PUB_RATE" ]; then
+        echo "Error: Failed to parse test results for size $SIZE, rate $RATE (run $RUN)"
+        echo "MIN_MS=$MIN_MS, MEDIAN_MS=$MEDIAN_MS, PUB_RATE=$PUB_RATE"
+        exit 1
+      fi
+      
+      # Format latency values to 2 decimal places
+      MIN_MS=$(printf "%.2f" "$MIN_MS")
+      MEDIAN_MS=$(printf "%.2f" "$MEDIAN_MS")
+      P75_MS=$(printf "%.2f" "$P75_MS")
+      P95_MS=$(printf "%.2f" "$P95_MS")
+      P99_MS=$(printf "%.2f" "$P99_MS")
+
+      # Calculate bandwidth in MiB/s and format to 2 decimal places
+      PUB_BW=$(echo "scale=2; ($SIZE * $PUB_RATE) / (1024 * 1024)" | bc)
+      CON_BW=$(echo "scale=2; ($SIZE * $CON_RATE) / (1024 * 1024)" | bc)
+      
+      # Ensure leading zero for values < 1.0
+      [[ "$PUB_BW" =~ ^\. ]] && PUB_BW="0$PUB_BW"
+      [[ "$CON_BW" =~ ^\. ]] && CON_BW="0$CON_BW"
+
+      # Format bandwidth to exactly 2 decimal places
+      PUB_BW=$(printf "%.2f" "$PUB_BW")
+      CON_BW=$(printf "%.2f" "$CON_BW")
+      
+      echo "Results: Latency min/median/p75/p95/p99: ${MIN_MS}/${MEDIAN_MS}/${P75_MS}/${P95_MS}/${P99_MS} ms"
+      echo "         Publish rate: $PUB_RATE msgs/s"
+      echo "         Bandwidth: Publish=$PUB_BW MiB/s, Consume=$CON_BW MiB/s"
+      echo ""
+      
+      # Append to CSV: Run,RateLimit,Min,Median,P75,P95,P99,PubRate,PubBW,ConBW
+      echo "$RUN,$RATE,$MIN_MS,$MEDIAN_MS,$P75_MS,$P95_MS,$P99_MS,$PUB_RATE,$PUB_BW,$CON_BW" >> "$SIZE_CSV"
+    done
+
+    echo ""
+  done
 done
 
 echo "=========================================="
@@ -167,6 +180,7 @@ echo "Generating markdown summary..."
   echo "- Duration: $DURATION seconds (\`-z $DURATION\`)"
   echo "- Producers: 1 (\`-x 1\`)"
   echo "- Consumers: 1 (\`-y 1\`)"
+  echo "- Runs per combination: $NUM_RUNS"
   echo "- Message sizes: $SIZES bytes"
   echo "- Rate limits: $RATE_LIMITS msgs/s"
   echo "- Queue: $QUEUE_NAME"
@@ -179,30 +193,74 @@ echo "Generating markdown summary..."
   echo "- Publish rate: (msgs/s)"
   echo "- Publish/consume bandwidth: (MiB/s)"
   echo ""
-  
+
   # Generate a table for each message size
   for SIZE in "${SIZE_ARRAY[@]}"; do
     SIZE_CSV="$TEMP_DIR/size_${SIZE}.csv"
-    
+
     echo "## Message Size: $SIZE bytes"
     echo ""
-    echo "| Rate Limit |     Min |  Median |     P75 |     P95 |      P99 | Pub. Rate |  Pub. BW |  Con. BW |"
-    echo "|-----------:|--------:|--------:|--------:|--------:|---------:|----------:|---------:|---------:|"
-    
-    # Read CSV and format as markdown table (skip header)
-    tail -n +2 "$SIZE_CSV" | while IFS=',' read -r rate min_lat median_lat p75_lat p95_lat p99_lat pub_rate pub_bw con_bw; do
-      formatted_rate=$(format_number "$rate")
-      formatted_pub_rate=$(format_number "$pub_rate")
-      # Ensure leading zeros for bandwidth values
-      [[ "$pub_bw" =~ ^\. ]] && pub_bw="0$pub_bw"
-      [[ "$con_bw" =~ ^\. ]] && con_bw="0$con_bw"
-      printf "| %10s | %7s | %7s | %7s | %7s | %8s | %9s | %8s | %8s |\n" \
-        "$formatted_rate" "$min_lat" "$median_lat" "$p75_lat" "$p95_lat" "$p99_lat" "$formatted_pub_rate" "$pub_bw" "$con_bw"
-    done
-    
+
+    if [ "$NUM_RUNS" -eq 1 ]; then
+      echo "| Rate Limit |     Min |  Median |     P75 |     P95 |      P99 | Pub. Rate |  Pub. BW |  Con. BW |"
+      echo "|-----------:|--------:|--------:|--------:|--------:|---------:|----------:|---------:|---------:|"
+
+      # Read CSV and format as markdown table (skip header row, skip Run column)
+      tail -n +2 "$SIZE_CSV" | while IFS=',' read -r run rate min_lat median_lat p75_lat p95_lat p99_lat pub_rate pub_bw con_bw; do
+        formatted_rate=$(format_number "$rate")
+        formatted_pub_rate=$(format_number "$pub_rate")
+        [[ "$pub_bw" =~ ^\. ]] && pub_bw="0$pub_bw"
+        [[ "$con_bw" =~ ^\. ]] && con_bw="0$con_bw"
+        printf "| %10s | %7s | %7s | %7s | %7s | %8s | %9s | %8s | %8s |\n" \
+          "$formatted_rate" "$min_lat" "$median_lat" "$p75_lat" "$p95_lat" "$p99_lat" "$formatted_pub_rate" "$pub_bw" "$con_bw"
+      done
+    else
+      # Per-run tables
+      for RUN in $(seq 1 "$NUM_RUNS"); do
+        echo "### Run $RUN of $NUM_RUNS"
+        echo ""
+        echo "| Rate Limit |     Min |  Median |     P75 |     P95 |      P99 | Pub. Rate |  Pub. BW |  Con. BW |"
+        echo "|-----------:|--------:|--------:|--------:|--------:|---------:|----------:|---------:|---------:|"
+
+        awk -F',' -v run="$RUN" '$1 == run' "$SIZE_CSV" | while IFS=',' read -r run rate min_lat median_lat p75_lat p95_lat p99_lat pub_rate pub_bw con_bw; do
+          formatted_rate=$(format_number "$rate")
+          formatted_pub_rate=$(format_number "$pub_rate")
+          [[ "$pub_bw" =~ ^\. ]] && pub_bw="0$pub_bw"
+          [[ "$con_bw" =~ ^\. ]] && con_bw="0$con_bw"
+          printf "| %10s | %7s | %7s | %7s | %7s | %8s | %9s | %8s | %8s |\n" \
+            "$formatted_rate" "$min_lat" "$median_lat" "$p75_lat" "$p95_lat" "$p99_lat" "$formatted_pub_rate" "$pub_bw" "$con_bw"
+        done
+        echo ""
+      done
+
+      # Summary table (median across runs per rate — robust against single-run spikes)
+      echo "### Summary ($NUM_RUNS runs)"
+      echo ""
+      echo "| Rate Limit |     Min |  Median |     P75 |     P95 |      P99 | Pub. Rate |  Pub. BW |  Con. BW |"
+      echo "|-----------:|--------:|--------:|--------:|--------:|---------:|----------:|---------:|---------:|"
+
+      for RATE in "${RATE_ARRAY[@]}"; do
+        MED_MIN=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$3} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
+        MED_MEDIAN=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$4} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
+        MED_P75=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$5} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
+        MED_P95=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$6} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
+        MED_P99=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$7} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
+        MED_PUB_RATE=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$8} END {asort(vals); m=int(n/2)+1; printf "%d", vals[m]}' "$SIZE_CSV")
+        MED_PUB_BW=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$9} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
+        MED_CON_BW=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$10} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
+
+        formatted_rate=$(format_number "$RATE")
+        formatted_pub_rate=$(format_number "$MED_PUB_RATE")
+        [[ "$MED_PUB_BW" =~ ^\. ]] && MED_PUB_BW="0$MED_PUB_BW"
+        [[ "$MED_CON_BW" =~ ^\. ]] && MED_CON_BW="0$MED_CON_BW"
+        printf "| %10s | %7s | %7s | %7s | %7s | %8s | %9s | %8s | %8s |\n" \
+          "$formatted_rate" "$MED_MIN" "$MED_MEDIAN" "$MED_P75" "$MED_P95" "$MED_P99" "$formatted_pub_rate" "$MED_PUB_BW" "$MED_CON_BW"
+      done
+    fi
+
     echo ""
   done
-  
+
 } > "$OUTPUT_FILE"
 
 echo "Results saved to: $OUTPUT_FILE"

--- a/scripts/run_multiple_throughput_tests.sh
+++ b/scripts/run_multiple_throughput_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script to run multiple throughput tests with different message sizes
-# Usage: ./run_multiple_throughput_tests.sh <broker_ip> [size1,size2,size3,...] [duration] [broker_instance_type]
+# Usage: ./run_multiple_throughput_tests.sh <broker_ip> [size1,size2,size3,...] [duration] [broker_instance_type] [num_runs]
 
 set -e  # Exit on error
 
@@ -17,13 +17,14 @@ BROKER_IP="${1}"
 SIZES="${2:-16,64,256,512,1024}"  # Default sizes if not provided
 DURATION="${3:-120}"  # Default duration 120 seconds if not provided
 BROKER_INSTANCE_TYPE="${4:-unknown}"  # Broker instance type for reporting
+NUM_RUNS="${5:-${BENCHMARK_NUM_RUNS:-1}}"  # Number of runs per size, default 1
 OUTPUT_FILE="/home/ubuntu/throughput_results.md"
 TEMP_CSV="/tmp/throughput_results.csv"
 QUEUE_NAME="perf-test"
 
 if [ -z "$BROKER_IP" ]; then
   echo "Error: Broker IP not provided"
-  echo "Usage: $0 <broker_ip> [size1,size2,size3,...] [duration] [broker_instance_type]"
+  echo "Usage: $0 <broker_ip> [size1,size2,size3,...] [duration] [broker_instance_type] [num_runs]"
   exit 1
 fi
 
@@ -49,62 +50,70 @@ echo "Broker Instance Type: $BROKER_INSTANCE_TYPE"
 echo "LavinMQ Version: $LAVINMQ_VERSION"
 echo "Message Sizes: $SIZES"
 echo "Test Duration: $DURATION seconds"
+echo "Number of Runs: $NUM_RUNS"
 echo "Output File: $OUTPUT_FILE"
 echo "=========================================="
 echo ""
 
 # Initialize CSV temp file
-echo "Size,Pub_Rate,Con_Rate,Pub_BW,Con_BW" > "$TEMP_CSV"
+echo "Run,Size,Pub_Rate,Con_Rate,Pub_BW,Con_BW" > "$TEMP_CSV"
 
 # Convert comma-separated sizes to array
 IFS=',' read -ra SIZE_ARRAY <<< "$SIZES"
 
-# Run test for each size
-for SIZE in "${SIZE_ARRAY[@]}"; do
-  echo "--------------------------------------"
-  echo "Testing with message size: $SIZE bytes"
-  echo "--------------------------------------"
-  
-  # Purge the queue before test using HTTP API
-  echo "Purging queue '$QUEUE_NAME' via HTTP API..."
-  PURGE_RESPONSE=$(curl -s -w "\n%{http_code}" --request DELETE \
-    --url "http://$BROKER_IP:15672/api/queues/%2F/$QUEUE_NAME/contents" \
-    --header 'Accept: application/json' \
-    --header 'Authorization: Basic cGVyZnRlc3Q6cGVyZnRlc3Q=' 2>&1) # perftest:perftest in base64
-  
-  HTTP_CODE=$(echo "$PURGE_RESPONSE" | tail -n1)
-  if [ "$HTTP_CODE" = "204" ] || [ "$HTTP_CODE" = "200" ]; then
-    echo "Queue purged successfully"
-  else
-    echo "Warning: Queue purge returned HTTP $HTTP_CODE (queue may not exist yet or already empty)"
-  fi
-  
-  # Run the throughput test
-  echo "Running throughput test (size=$SIZE, duration=$DURATION seconds)..."
-  TEST_OUTPUT=$(lavinmqperf throughput -z "$DURATION" -x 1 -y 1 -s "$SIZE" \
-    --uri="amqp://perftest:perftest@$BROKER_IP" 2>&1)
-  
-  # Display the output
-  echo "$TEST_OUTPUT"
-  
-  # Parse the results
-  PUB_RATE=$(echo "$TEST_OUTPUT" | grep "Average publish rate:" | awk '{print $4}')
-  CON_RATE=$(echo "$TEST_OUTPUT" | grep "Average consume rate:" | awk '{print $4}')
-  
-  if [ -z "$PUB_RATE" ] || [ -z "$CON_RATE" ]; then
-    echo "Error: Failed to parse test results for size $SIZE"
-    exit 1
-  fi
-  
-  # Calculate bandwidth in MiB/s: (size_bytes * msgs_per_sec) / (1024 * 1024)
-  PUB_BW=$(echo "scale=2; ($SIZE * $PUB_RATE) / (1024 * 1024)" | bc)
-  CON_BW=$(echo "scale=2; ($SIZE * $CON_RATE) / (1024 * 1024)" | bc)
-
-  echo "Results: Publish=$PUB_RATE msgs/s ($PUB_BW MiB/s), Consume=$CON_RATE msgs/s ($CON_BW MiB/s)"
+# Run tests: outer loop = runs, inner loop = sizes
+for RUN in $(seq 1 "$NUM_RUNS"); do
+  echo "=========================================="
+  echo "Run $RUN of $NUM_RUNS"
+  echo "=========================================="
   echo ""
-  
-  # Append to CSV
-  echo "$SIZE,$PUB_RATE,$CON_RATE,$PUB_BW,$CON_BW" >> "$TEMP_CSV"
+
+  for SIZE in "${SIZE_ARRAY[@]}"; do
+    echo "--------------------------------------"
+    echo "Run $RUN/$NUM_RUNS — message size: $SIZE bytes"
+    echo "--------------------------------------"
+    
+    # Purge the queue before test using HTTP API
+    echo "Purging queue '$QUEUE_NAME' via HTTP API..."
+    PURGE_RESPONSE=$(curl -s -w "\n%{http_code}" --request DELETE \
+      --url "http://$BROKER_IP:15672/api/queues/%2F/$QUEUE_NAME/contents" \
+      --header 'Accept: application/json' \
+      --header 'Authorization: Basic cGVyZnRlc3Q6cGVyZnRlc3Q=' 2>&1) # perftest:perftest in base64
+    
+    HTTP_CODE=$(echo "$PURGE_RESPONSE" | tail -n1)
+    if [ "$HTTP_CODE" = "204" ] || [ "$HTTP_CODE" = "200" ]; then
+      echo "Queue purged successfully"
+    else
+      echo "Warning: Queue purge returned HTTP $HTTP_CODE (queue may not exist yet or already empty)"
+    fi
+    
+    # Run the throughput test
+    echo "Running throughput test (size=$SIZE, duration=$DURATION seconds)..."
+    TEST_OUTPUT=$(lavinmqperf throughput -z "$DURATION" -x 1 -y 1 -s "$SIZE" \
+      --uri="amqp://perftest:perftest@$BROKER_IP" 2>&1)
+    
+    # Display the output
+    echo "$TEST_OUTPUT"
+    
+    # Parse the results
+    PUB_RATE=$(echo "$TEST_OUTPUT" | grep "Average publish rate:" | awk '{print $4}')
+    CON_RATE=$(echo "$TEST_OUTPUT" | grep "Average consume rate:" | awk '{print $4}')
+    
+    if [ -z "$PUB_RATE" ] || [ -z "$CON_RATE" ]; then
+      echo "Error: Failed to parse test results for size $SIZE (run $RUN)"
+      exit 1
+    fi
+    
+    # Calculate bandwidth in MiB/s: (size_bytes * msgs_per_sec) / (1024 * 1024)
+    PUB_BW=$(echo "scale=2; ($SIZE * $PUB_RATE) / (1024 * 1024)" | bc)
+    CON_BW=$(echo "scale=2; ($SIZE * $CON_RATE) / (1024 * 1024)" | bc)
+
+    echo "Results: Publish=$PUB_RATE msgs/s ($PUB_BW MiB/s), Consume=$CON_RATE msgs/s ($CON_BW MiB/s)"
+    echo ""
+    
+    # Append to CSV: Run,Size,Pub_Rate,Con_Rate,Pub_BW,Con_BW
+    echo "$RUN,$SIZE,$PUB_RATE,$CON_RATE,$PUB_BW,$CON_BW" >> "$TEMP_CSV"
+  done
 done
 
 echo "=========================================="
@@ -128,22 +137,64 @@ echo "Generating markdown summary..."
   echo "- Average publish/consume rates: (msgs/s)"
   echo "- Publish/Consume bandwidth: (MiB/s)"
   echo ""
-  echo "|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |"
-  echo "|------:|------------------:|------------------:|------------:|------------:|"
-  
-  # Read CSV and format as markdown table (skip header)
-  tail -n +2 "$TEMP_CSV" | while IFS=',' read -r size pub_rate con_rate pub_bw con_bw; do
-    formatted_pub=$(format_number "$pub_rate")
-    formatted_con=$(format_number "$con_rate")
-    printf "| %5s | %17s | %17s | %11s | %11s |\n" "$size" "$formatted_pub" "$formatted_con" "$pub_bw" "$con_bw"
-  done
-  
+
+  if [ "$NUM_RUNS" -eq 1 ]; then
+    # Single run: emit the same table format as before
+    echo "|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |"
+    echo "|------:|------------------:|------------------:|------------:|------------:|"
+    tail -n +2 "$TEMP_CSV" | while IFS=',' read -r run size pub_rate con_rate pub_bw con_bw; do
+      formatted_pub=$(format_number "$pub_rate")
+      formatted_con=$(format_number "$con_rate")
+      printf "| %5s | %17s | %17s | %11s | %11s |\n" "$size" "$formatted_pub" "$formatted_con" "$pub_bw" "$con_bw"
+    done
+  else
+    # Multiple runs: one table per run, then a summary table
+    for RUN in $(seq 1 "$NUM_RUNS"); do
+      echo "### Run $RUN of $NUM_RUNS"
+      echo ""
+      echo "|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |"
+      echo "|------:|------------------:|------------------:|------------:|------------:|"
+      grep "^$RUN," "$TEMP_CSV" | while IFS=',' read -r run size pub_rate con_rate pub_bw con_bw; do
+        formatted_pub=$(format_number "$pub_rate")
+        formatted_con=$(format_number "$con_rate")
+        printf "| %5s | %17s | %17s | %11s | %11s |\n" "$size" "$formatted_pub" "$formatted_con" "$pub_bw" "$con_bw"
+      done
+      echo ""
+    done
+
+    # Summary table: avg publish and consume rate per size
+    echo "### Summary (${NUM_RUNS} runs)"
+    echo ""
+    echo "|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |"
+    echo "|------:|------------------:|------------------:|------------:|------------:|"
+    for SIZE in "${SIZE_ARRAY[@]}"; do
+      # Collect all pub_rates, con_rates, and bandwidths for this size across runs
+      PUB_RATES=$(grep ",${SIZE}," "$TEMP_CSV" | awk -F',' '{print $3}')
+      CON_RATES=$(grep ",${SIZE}," "$TEMP_CSV" | awk -F',' '{print $4}')
+      PUB_BWS=$(grep ",${SIZE}," "$TEMP_CSV" | awk -F',' '{print $5}')
+      CON_BWS=$(grep ",${SIZE}," "$TEMP_CSV" | awk -F',' '{print $6}')
+
+      AVG_PUB=$(echo "$PUB_RATES" | awk '{s+=$1; n++} END {printf "%d", s/n}')
+      AVG_CON=$(echo "$CON_RATES" | awk '{s+=$1; n++} END {printf "%d", s/n}')
+      AVG_PUB_BW=$(echo "$PUB_BWS" | awk '{s+=$1; n++} END {printf "%.2f", s/n}')
+      AVG_CON_BW=$(echo "$CON_BWS" | awk '{s+=$1; n++} END {printf "%.2f", s/n}')
+
+      printf "| %5s | %17s | %17s | %11s | %11s |\n" \
+        "$SIZE" \
+        "$(format_number "$AVG_PUB")" \
+        "$(format_number "$AVG_CON")" \
+        "$AVG_PUB_BW" \
+        "$AVG_CON_BW"
+    done
+  fi
+
   echo ""
   echo "## Test Configuration"
   echo ""
   echo "- Duration: $DURATION seconds (\`-z $DURATION\`)"
   echo "- Producers: 1 (\`-x 1\`)"
   echo "- Consumers: 1 (\`-y 1\`)"
+  echo "- Runs per size: $NUM_RUNS"
   echo "- Message sizes: $SIZES bytes"
   echo "- Queue: $QUEUE_NAME"
   echo ""

--- a/scripts/run_multiple_throughput_tests.sh
+++ b/scripts/run_multiple_throughput_tests.sh
@@ -162,29 +162,23 @@ echo "Generating markdown summary..."
       echo ""
     done
 
-    # Summary table: avg publish and consume rate per size
+    # Summary table: median publish and consume rate per size (robust against single-run spikes)
     echo "### Summary (${NUM_RUNS} runs)"
     echo ""
     echo "|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |"
     echo "|------:|------------------:|------------------:|------------:|------------:|"
     for SIZE in "${SIZE_ARRAY[@]}"; do
-      # Collect all pub_rates, con_rates, and bandwidths for this size across runs
-      PUB_RATES=$(grep ",${SIZE}," "$TEMP_CSV" | awk -F',' '{print $3}')
-      CON_RATES=$(grep ",${SIZE}," "$TEMP_CSV" | awk -F',' '{print $4}')
-      PUB_BWS=$(grep ",${SIZE}," "$TEMP_CSV" | awk -F',' '{print $5}')
-      CON_BWS=$(grep ",${SIZE}," "$TEMP_CSV" | awk -F',' '{print $6}')
-
-      AVG_PUB=$(echo "$PUB_RATES" | awk '{s+=$1; n++} END {printf "%d", s/n}')
-      AVG_CON=$(echo "$CON_RATES" | awk '{s+=$1; n++} END {printf "%d", s/n}')
-      AVG_PUB_BW=$(echo "$PUB_BWS" | awk '{s+=$1; n++} END {printf "%.2f", s/n}')
-      AVG_CON_BW=$(echo "$CON_BWS" | awk '{s+=$1; n++} END {printf "%.2f", s/n}')
+      MED_PUB=$(awk -F',' -v s="$SIZE" '$2 == s {vals[++n]=$3} END {asort(vals); m=int(n/2)+1; printf "%d", vals[m]}' "$TEMP_CSV")
+      MED_CON=$(awk -F',' -v s="$SIZE" '$2 == s {vals[++n]=$4} END {asort(vals); m=int(n/2)+1; printf "%d", vals[m]}' "$TEMP_CSV")
+      MED_PUB_BW=$(awk -F',' -v s="$SIZE" '$2 == s {vals[++n]=$5} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$TEMP_CSV")
+      MED_CON_BW=$(awk -F',' -v s="$SIZE" '$2 == s {vals[++n]=$6} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$TEMP_CSV")
 
       printf "| %5s | %17s | %17s | %11s | %11s |\n" \
         "$SIZE" \
-        "$(format_number "$AVG_PUB")" \
-        "$(format_number "$AVG_CON")" \
-        "$AVG_PUB_BW" \
-        "$AVG_CON_BW"
+        "$(format_number "$MED_PUB")" \
+        "$(format_number "$MED_CON")" \
+        "$MED_PUB_BW" \
+        "$MED_CON_BW"
     done
   fi
 


### PR DESCRIPTION
### WHY are these changes introduced?

To get more reliable results from throughput and latency. Run multiple runs per combination.

### WHAT is this pull request doing?

- Adds env. variable to change number of combination runs.
- Updates script to change number of combination runs.
- Adds additional message sizes [4069, 16384, 65536]
- Adds support for rate-limit override, during latency runs.

### HOW was this pull request tested?

Been running throughput and latency runs for v2.7.0-rc.2 #38