### PR TITLE
Add MQTT throughput scenario

### DIFF
--- a/modules/lavinmq/terraform_data.tf
+++ b/modules/lavinmq/terraform_data.tf
@@ -80,6 +80,7 @@ resource "terraform_data" "create_user" {
 
   provisioner "remote-exec" {
     inline = [
+      "until sudo lavinmqctl list_users > /dev/null 2>&1; do sleep 1; done",
       "sudo lavinmqctl add_user perftest perftest",
       "sudo lavinmqctl set_user_tags perftest administrator",
       "sudo lavinmqctl set_permissions perftest '.*' '.*' '.*'"

--- a/modules/mqtt_tools/terraform_data.tf
+++ b/modules/mqtt_tools/terraform_data.tf
@@ -1,0 +1,22 @@
+resource "terraform_data" "install_mqtt_tools" {
+  count = var.install_mqtt_tools == false ? 0 : 1
+
+  connection {
+    type  = "ssh"
+    user  = "ubuntu"
+    host  = var.public_dns
+    agent = true
+  }
+
+  provisioner "file" {
+    source      = "../../../scripts/install_mqtt_tools.sh"
+    destination = "/tmp/install_mqtt_tools.sh"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo chmod +x /tmp/install_mqtt_tools.sh",
+      "sudo /tmp/install_mqtt_tools.sh",
+    ]
+  }
+}

--- a/modules/mqtt_tools/variables.tf
+++ b/modules/mqtt_tools/variables.tf
@@ -1,0 +1,8 @@
+variable "public_dns" {
+  type = string
+}
+
+variable "install_mqtt_tools" {
+  type    = bool
+  default = false
+}

--- a/modules/providers/aws/instance/instance.tf
+++ b/modules/providers/aws/instance/instance.tf
@@ -6,12 +6,29 @@ variable "subnet_id" {}
 variable "tag_created_by" {}
 variable "tag_name" {}
 variable "volume_size" {}
+variable "secondary_private_ip_count" {
+  default = 0
+}
+
+resource "aws_network_interface" "primary" {
+  subnet_id         = var.subnet_id
+  private_ips_count = var.secondary_private_ip_count
+
+  tags = {
+    Name      = var.tag_name
+    CreatedBy = var.tag_created_by
+  }
+}
 
 resource "aws_instance" "instance" {
   ami           = var.ami_id
   instance_type = var.instance_type
-  subnet_id     = var.subnet_id
   key_name      = var.ssh_key_pair_name
+
+  network_interface {
+    network_interface_id = aws_network_interface.primary.id
+    device_index         = 0
+  }
 
   root_block_device {
     volume_size = var.volume_size

--- a/modules/providers/aws/load_generator/main.tf
+++ b/modules/providers/aws/load_generator/main.tf
@@ -1,13 +1,14 @@
 module "instance" {
   source = "../instance"
 
-  ami_id            = var.ami_id
-  instance_type     = var.instance_type
-  ssh_key_pair_name = var.ssh_key_name
-  subnet_id         = var.subnet_id
-  tag_created_by    = var.tag_created_by
-  tag_name          = var.tag_name
-  volume_size       = var.volume_size
+  ami_id                     = var.ami_id
+  instance_type              = var.instance_type
+  ssh_key_pair_name          = var.ssh_key_name
+  subnet_id                  = var.subnet_id
+  tag_created_by             = var.tag_created_by
+  tag_name                   = var.tag_name
+  volume_size                = var.volume_size
+  secondary_private_ip_count = var.secondary_private_ip_count
 }
 
 module "install_lavinmq" {

--- a/modules/providers/aws/load_generator/variables.tf
+++ b/modules/providers/aws/load_generator/variables.tf
@@ -54,3 +54,9 @@ variable stop_lavinmq {
   type    = bool
   default = false
 }
+
+variable "secondary_private_ip_count" {
+  description = "Number of secondary private IPs to assign (for high connection count tests)"
+  type        = number
+  default     = 0
+}

--- a/modules/providers/aws/network/network.tf
+++ b/modules/providers/aws/network/network.tf
@@ -72,6 +72,20 @@ resource "aws_vpc_security_group_ingress_rule" "amqp_internal" {
   }
 }
 
+resource "aws_vpc_security_group_ingress_rule" "mqtt_internal" {
+  security_group_id = aws_vpc.vpc.default_security_group_id
+
+  cidr_ipv4   = aws_vpc.vpc.cidr_block
+  ip_protocol = "tcp"
+  from_port   = 1883
+  to_port     = 1883
+
+  tags = {
+    Name      = "${var.tag_name}-mqtt"
+    CreatedBy = var.tag_created_by
+  }
+}
+
 resource "aws_vpc_security_group_ingress_rule" "http_api_internal" {
   security_group_id = aws_vpc.vpc.default_security_group_id
 

--- a/modules/providers/aws/ssh/ssh.tf
+++ b/modules/providers/aws/ssh/ssh.tf
@@ -3,5 +3,5 @@ variable ssh_key_name {}
 
 resource "aws_key_pair" "ssh_key" {
   key_name   = var.ssh_key_name
-  public_key = file(var.public_ssh_key)
+  public_key = file(pathexpand(var.public_ssh_key))
 }

--- a/scenarios/aws/mqtt_throughput/README.md
+++ b/scenarios/aws/mqtt_throughput/README.md
@@ -1,0 +1,121 @@
+# MQTT Throughput Benchmark
+
+This scenario provisions AWS infrastructure, installs LavinMQ and MQTT benchmark tools, and runs sequential
+MQTT throughput tests with different message sizes against the broker, summarizing results in a markdown table.
+
+## What It Does
+
+1. **Provisions AWS Infrastructure**:
+   - VPC with subnet and security groups (including MQTT port 1883)
+   - One broker instance with LavinMQ installed and running
+   - One load generator instance with LavinMQ tools and MQTT benchmark tools (`emqtt-bench`, `mqttloader`) installed
+
+2. **Runs Sequential Tests**:
+   - For each configured message size, runs an MQTT throughput test via the `mqtt_bench.sh` wrapper (driving `emqtt-bench`)
+   - Captures publish and consume rates and computes bandwidth
+
+3. **Generates Results**:
+   - Writes a markdown summary to `/home/ubuntu/mqtt_throughput_results.md` on the load generator
+   - Outputs SSH/SCP commands to view or download the file
+
+## Prerequisites
+
+- Terraform >= 1.3.0
+- AWS credentials configured
+- SSH key pair for instance access
+- `dotenv` for loading environment variables (optional but recommended)
+
+## Configuration
+
+### Required Variables
+
+Configure these in your `.env` file or pass via `-var` flags:
+
+```bash
+# AWS Credentials
+AWS_ACCESS_KEY=***
+AWS_SECRET_KEY=***
+
+# AWS region
+TF_VAR_aws_region="us-east-1"
+TF_VAR_aws_availability_zone="us-east-1a"
+
+# SSH key access, path to your public key and name the key.
+TF_VAR_public_ssh_key="~/.ssh/id_ed25519.pub"
+TF_VAR_ssh_key_name="lavinmq-benchmark"
+
+# Information set to AWS resources
+TF_VAR_tag_created_by="test@benchmark"
+TF_VAR_tag_name="lavinmq-benchmark"
+
+# Benchmark servers
+# Broker server
+TF_VAR_broker_instance_type="c8g.large"
+TF_VAR_broker_name="Benchmark-broker"
+
+# Load generator server
+TF_VAR_load_generator_instance_type="c8g.large"
+TF_VAR_load_generator_name="Benchmark-loadgen"
+```
+
+### Optional Variables (with defaults)
+
+```bash
+# Infrastructure
+TF_VAR_ami_arch="arm64"               # or "amd64"
+TF_VAR_ubuntu_code_name="noble"       # Ubuntu version
+
+# Benchmark server
+TF_VAR_broker_volume_size=8           # Root disk size in GB
+TF_VAR_load_generator_volume_size=8   # Root disk size in GB
+TF_VAR_lavinmq_version=""             # Empty = latest, or specify a version
+
+# Test configuration
+TF_VAR_message_sizes=[16,64,256,512,1024]   # Message sizes in bytes
+TF_VAR_test_duration=120                    # Duration of each test in seconds
+```
+
+## Usage
+
+### 1. Initialize Terraform
+
+```bash
+cd scenarios/aws/mqtt_throughput
+terraform init
+```
+
+### 2. Create the setup and run the throughput tests
+
+```bash
+dotenv terraform apply
+```
+
+### 3. Re-run the tests
+
+Force-replace the test resource without recreating instances:
+
+```bash
+dotenv terraform apply -replace='terraform_data.mqtt_throughput_tests'
+```
+
+### 4. Change test parameters
+
+Change any parameter and Terraform will automatically replace the test resource:
+
+```bash
+dotenv terraform apply -var='message_sizes=[16,64,256]' -var='test_duration=60'
+```
+
+### 5. View results
+
+After apply finishes, use the SSH/SCP commands from the Terraform outputs:
+
+```bash
+ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known-hosts ubuntu@<load-generator-dns> 'cat /home/ubuntu/mqtt_throughput_results.md'
+```
+
+### 6. Clean up resources
+
+```bash
+dotenv terraform destroy
+```

--- a/scenarios/aws/mqtt_throughput/main.tf
+++ b/scenarios/aws/mqtt_throughput/main.tf
@@ -1,0 +1,154 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "network" {
+  source = "../../../modules/providers/aws/network"
+
+  aws_availability_zone = var.aws_availability_zone
+  tag_created_by        = var.tag_created_by
+  tag_name              = var.tag_name
+}
+
+module "ssh" {
+  source = "../../../modules/providers/aws/ssh"
+
+  ssh_key_name   = var.ssh_key_name
+  public_ssh_key = var.public_ssh_key
+}
+
+module "ami" {
+  source = "../../../modules/providers/aws/ami"
+
+  ami_arch         = var.ami_arch
+  ubuntu_code_name = var.ubuntu_code_name
+}
+
+module "broker" {
+  source = "../../../modules/providers/aws/broker"
+
+  # Create AWS instance
+  ami_id         = module.ami.ami_id
+  instance_type  = var.broker_instance_type
+  ssh_key_name   = var.ssh_key_name
+  subnet_id      = module.network.subnet_identifier
+  tag_created_by = var.tag_created_by
+  tag_name       = var.broker_name
+  volume_size    = var.broker_volume_size
+
+  # Install lavinmq
+  install_crystal     = true
+  lavinmq_version     = var.lavinmq_version
+  install_lavinmq     = true
+  configure_lavinmq   = true
+  create_lavinmq_user = true
+}
+
+module "load_generator" {
+  source = "../../../modules/providers/aws/load_generator"
+
+  # Create AWS instance
+  ami_id         = module.ami.ami_id
+  instance_type  = var.load_generator_instance_type
+  ssh_key_name   = var.ssh_key_name
+  subnet_id      = module.network.subnet_identifier
+  tag_name       = var.load_generator_name
+  tag_created_by = var.tag_created_by
+  volume_size    = var.load_generator_volume_size
+
+  # Install lavinmq (for lavinmqperf, not used here but keeps instance consistent) # TODO
+  install_crystal = true
+  lavinmq_version = ""
+  install_lavinmq = true
+  stop_lavinmq    = true
+}
+
+# Install MQTT benchmark tools on load generator
+module "mqtt_tools" {
+  source = "../../../modules/mqtt_tools"
+
+  public_dns         = module.load_generator.public_dns
+  install_mqtt_tools = true
+
+  depends_on = [module.load_generator]
+}
+
+# Run multiple MQTT throughput tests
+resource "terraform_data" "mqtt_throughput_tests" {
+  connection {
+    type  = "ssh"
+    user  = "ubuntu"
+    host  = module.load_generator.public_dns
+    agent = true
+  }
+
+  # Trigger replacement when test parameters change
+  triggers_replace = [
+    join(",", var.message_sizes),
+    var.test_duration,
+    var.broker_instance_type,
+    var.lavinmq_version
+  ]
+
+  # Upload test scripts
+  provisioner "file" {
+    source      = "../../../scripts/mqtt_bench.sh"
+    destination = "/home/ubuntu/mqtt_bench.sh"
+  }
+
+  provisioner "file" {
+    source      = "../../../scripts/run_mqtt_throughput_tests.sh"
+    destination = "/home/ubuntu/run_mqtt_throughput_tests.sh"
+  }
+
+  # Execute the multiple test runs
+  provisioner "remote-exec" {
+    inline = [
+      "chmod +x /home/ubuntu/mqtt_bench.sh /home/ubuntu/run_mqtt_throughput_tests.sh",
+      format("/home/ubuntu/run_mqtt_throughput_tests.sh %s %s %s %s",
+        module.broker.private_ip,
+        join(",", var.message_sizes),
+        var.test_duration,
+        var.broker_instance_type
+      )
+    ]
+  }
+
+  depends_on = [module.broker.user_ids, module.mqtt_tools]
+}
+
+# Outputs
+output "broker_public_dns" {
+  description = "Public DNS name of the broker instance"
+  value       = module.broker.public_dns
+}
+
+output "load_generator_public_dns" {
+  description = "Public DNS name of the load generator instance"
+  value       = module.load_generator.public_dns
+}
+
+output "results_file_path" {
+  description = "Path to the results file on the load generator instance"
+  value       = "/home/ubuntu/mqtt_throughput_results.md"
+}
+
+output "ssh_view_results_command" {
+  description = "Command to SSH and view the results"
+  value       = format("ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known-hosts ubuntu@%s 'cat /home/ubuntu/mqtt_throughput_results.md'", module.load_generator.public_dns)
+}
+
+output "scp_download_results_command" {
+  description = "Command to download the results file using SCP"
+  value       = format("scp -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known-hosts ubuntu@%s:/home/ubuntu/mqtt_throughput_results.md ./mqtt_throughput_results.md", module.load_generator.public_dns)
+}

--- a/scenarios/aws/mqtt_throughput/variables.tf
+++ b/scenarios/aws/mqtt_throughput/variables.tf
@@ -1,0 +1,90 @@
+# AWS variables
+## AWS region and AZ
+variable "aws_region" {
+  type = string
+}
+
+variable "aws_availability_zone" {
+  type = string
+}
+
+## Tag the AWS resources
+variable "tag_created_by" {
+  type = string
+}
+
+variable "tag_name" {
+  type = string
+}
+
+## AMI architecture
+variable "ami_arch" {
+  type    = string
+  default = "arm64"
+}
+
+## Ubuntu code name
+variable "ubuntu_code_name" {
+  type    = string
+  default = "noble"
+}
+
+# Public SSH key path
+variable "public_ssh_key" {
+  type = string
+}
+
+# SSH key name
+variable "ssh_key_name" {
+  type = string
+}
+
+# Benchmark servers
+
+variable "lavinmq_version" {
+  type    = string
+  default = ""
+}
+
+## Broker server
+variable "broker_instance_type" {
+  type = string
+}
+
+variable "broker_name" {
+  type = string
+}
+
+variable "broker_volume_size" {
+  description = "Set the root disk volume size"
+  type        = number
+  default     = 8
+}
+
+## Load generator server
+variable "load_generator_instance_type" {
+  type = string
+}
+
+variable "load_generator_name" {
+  type = string
+}
+
+variable "load_generator_volume_size" {
+  description = "Set the root disk volume size"
+  type        = number
+  default     = 8
+}
+
+# Test configuration
+variable "message_sizes" {
+  description = "List of message sizes in bytes to test"
+  type        = list(number)
+  default     = [16, 64, 256, 512, 1024]
+}
+
+variable "test_duration" {
+  description = "Duration of each test in seconds"
+  type        = number
+  default     = 120
+}

--- a/scripts/install_mqtt_tools.sh
+++ b/scripts/install_mqtt_tools.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -xe
+
+apt-get update -qq > /dev/null
+
+# Install Erlang 27 for emqtt-bench (Ubuntu default is too old)
+apt-get install -y -qq software-properties-common > /dev/null
+add-apt-repository -y ppa:rabbitmq/rabbitmq-erlang > /dev/null
+apt-get update -qq > /dev/null
+apt-get install -y -qq erlang > /dev/null
+
+# Install Java for mqttloader
+apt-get install default-jre unzip -y -qq > /dev/null
+
+# Build emqtt-bench
+TOOLS_DIR="/opt/mqtt-tools"
+mkdir -p "$TOOLS_DIR"
+
+cd "$TOOLS_DIR"
+rm -rf emqtt-bench
+git clone https://github.com/emqx/emqtt-bench.git
+cd emqtt-bench
+BUILD_WITHOUT_QUIC=1 make
+
+# Download mqttloader
+cd "$TOOLS_DIR"
+MQTTLOADER_VERSION="0.8.6"
+curl -sL "https://github.com/dist-sys/mqttloader/releases/download/v${MQTTLOADER_VERSION}/mqttloader-${MQTTLOADER_VERSION}.zip" -o mqttloader.zip
+unzip -q mqttloader.zip
+rm mqttloader.zip
+chmod +x mqttloader/bin/mqttloader
+
+# Create symlinks for easy access
+ln -sf "$TOOLS_DIR/emqtt-bench/_build/emqtt_bench/rel/emqtt_bench/bin/emqtt_bench" /usr/local/bin/emqtt_bench
+ln -sf "$TOOLS_DIR/mqttloader/bin/mqttloader" /usr/local/bin/mqttloader

--- a/scripts/mqtt_bench.sh
+++ b/scripts/mqtt_bench.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+
+# mqtt_bench.sh — Thin wrapper around emqtt-bench and mqttloader that mimics
+# lavinmqperf output format so MQTT test scripts can follow the same patterns.
+#
+# Usage:
+#   mqtt_bench.sh throughput -z <duration> -x <publishers> -y <consumers> -s <size> --uri=mqtt://user:pass@host
+#   mqtt_bench.sh throughput -z <duration> -x <publishers> -y <consumers> -s <size> -r <rate> --measure-latency --uri=mqtt://user:pass@host
+
+set -e
+
+COMMAND=""
+DURATION=120
+PUBLISHERS=1
+CONSUMERS=1
+SIZE=256
+RATE=0
+MEASURE_LATENCY=false
+BROKER_HOST=""
+BROKER_PORT=1883
+USERNAME=""
+PASSWORD=""
+TOPIC="mqtt-bench-test"
+
+# Parse arguments to match lavinmqperf interface
+parse_args() {
+  COMMAND="$1"
+  shift
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -z) DURATION="$2"; shift 2 ;;
+      -x) PUBLISHERS="$2"; shift 2 ;;
+      -y) CONSUMERS="$2"; shift 2 ;;
+      -s) SIZE="$2"; shift 2 ;;
+      -r) RATE="$2"; shift 2 ;;
+      --measure-latency) MEASURE_LATENCY=true; shift ;;
+      --uri=*)
+        URI="${1#--uri=}"
+        # Parse mqtt://user:pass@host or mqtt://user:pass@host:port
+        URI_BODY="${URI#*://}"
+        if [[ "$URI_BODY" == *"@"* ]]; then
+          CREDENTIALS="${URI_BODY%%@*}"
+          HOST_PART="${URI_BODY#*@}"
+          USERNAME="${CREDENTIALS%%:*}"
+          PASSWORD="${CREDENTIALS#*:}"
+          # Strip query string if present
+          HOST_PART="${HOST_PART%%\?*}"
+          if [[ "$HOST_PART" == *":"* ]]; then
+            BROKER_HOST="${HOST_PART%%:*}"
+            BROKER_PORT="${HOST_PART#*:}"
+          else
+            BROKER_HOST="$HOST_PART"
+          fi
+        else
+          HOST_PART="${URI_BODY%%\?*}"
+          if [[ "$HOST_PART" == *":"* ]]; then
+            BROKER_HOST="${HOST_PART%%:*}"
+            BROKER_PORT="${HOST_PART#*:}"
+          else
+            BROKER_HOST="$HOST_PART"
+          fi
+        fi
+        shift ;;
+      *) shift ;;
+    esac
+  done
+
+  if [ -z "$BROKER_HOST" ]; then
+    echo "Error: --uri is required"
+    exit 1
+  fi
+}
+
+# Build auth flags for emqtt-bench
+auth_flags() {
+  if [ -n "$USERNAME" ]; then
+    echo "-u $USERNAME -P $PASSWORD"
+  fi
+}
+
+# Run throughput test using emqtt-bench, output in lavinmqperf format
+run_throughput() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local auth
+  auth="$(auth_flags)"
+
+  # Start subscriber(s)
+  if [ "$CONSUMERS" -gt 0 ]; then
+    emqtt_bench sub \
+      -h "$BROKER_HOST" -p "$BROKER_PORT" \
+      -t "$TOPIC" \
+      -c "$CONSUMERS" -q 0 -V 4 $auth \
+      > "$tmpdir/sub.log" 2>&1 &
+    SUB_PID=$!
+    sleep 5
+  fi
+
+  # Start publishers
+  emqtt_bench pub \
+    -h "$BROKER_HOST" -p "$BROKER_PORT" \
+    -t "$TOPIC" \
+    -c "$PUBLISHERS" -s "$SIZE" -q 0 -I 0 -V 4 $auth \
+    > "$tmpdir/pub.log" 2>&1 &
+  PUB_PID=$!
+
+  sleep "$DURATION"
+
+  # Stop processes
+  for pid in ${PUB_PID:-} ${SUB_PID:-}; do
+    pkill -9 -P "$pid" 2>/dev/null || true
+    kill -9 "$pid" 2>/dev/null || true
+  done
+  wait $PUB_PID ${SUB_PID:-} 2>/dev/null || true
+  sleep 1
+
+  # Parse peak rates from emqtt-bench output
+  local pub_rate sub_rate
+  pub_rate=$(tr '\r' '\n' < "$tmpdir/pub.log" \
+    | sed -n 's/.*[0-9]s pub total=[0-9]* rate=\([0-9]*\)\..*/\1/p' \
+    | sort -rn | head -1)
+  pub_rate="${pub_rate:-0}"
+
+  if [ "$CONSUMERS" -gt 0 ]; then
+    sub_rate=$(tr '\r' '\n' < "$tmpdir/sub.log" \
+      | sed -n 's/.*[0-9]s recv total=[0-9]* rate=\([0-9]*\)\..*/\1/p' \
+      | sort -rn | head -1)
+    sub_rate="${sub_rate:-0}"
+  else
+    sub_rate=0
+  fi
+
+  # Output in lavinmqperf format
+  echo "Average publish rate: $pub_rate"
+  echo "Average consume rate: $sub_rate"
+
+  rm -rf "$tmpdir"
+}
+
+# Run latency test using mqttloader, output in lavinmqperf format
+run_latency() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+
+  # Calculate interval in microseconds from rate
+  local interval_us=0
+  if [ "$RATE" -gt 0 ]; then
+    interval_us=$((1000000 / RATE))
+  fi
+
+  # Calculate num_messages from rate and duration
+  local num_messages
+  if [ "$RATE" -gt 0 ]; then
+    num_messages=$((RATE * DURATION))
+  else
+    num_messages=1000000
+  fi
+
+  # Write mqttloader config
+  cat > "$tmpdir/mqttloader.conf" <<EOF
+broker = $BROKER_HOST
+broker_port = $BROKER_PORT
+mqtt_version = 3
+num_publishers = $PUBLISHERS
+num_subscribers = $CONSUMERS
+qos_publisher = 1
+qos_subscriber = 1
+payload = $SIZE
+interval = $interval_us
+num_messages = $num_messages
+exec_time = $DURATION
+topic = $TOPIC
+output = $tmpdir
+EOF
+
+  if [ -n "$USERNAME" ]; then
+    echo "user_name = $USERNAME" >> "$tmpdir/mqttloader.conf"
+    echo "password = $PASSWORD" >> "$tmpdir/mqttloader.conf"
+  fi
+
+  # Run mqttloader
+  local ml_output
+  ml_output=$(mqttloader -c "$tmpdir/mqttloader.conf" 2>&1) || true
+
+  # Parse throughput from mqttloader stdout
+  local pub_rate sub_rate
+  pub_rate=$(echo "$ml_output" | grep "Average throughput" | head -1 | grep -o '[0-9,.]*' | head -1 | tr -d ',')
+  sub_rate=$(echo "$ml_output" | grep "Average throughput" | tail -1 | grep -o '[0-9,.]*' | head -1 | tr -d ',')
+  pub_rate="${pub_rate%%.*}"
+  sub_rate="${sub_rate%%.*}"
+  pub_rate="${pub_rate:-0}"
+  sub_rate="${sub_rate:-0}"
+
+  # Compute latency percentiles from mqttloader CSV
+  local csv_file
+  csv_file="$(find "$tmpdir" -name 'mqttloader_*.csv' | head -1)"
+
+  local min_ms=0 median_ms=0 p75_ms=0 p95_ms=0 p99_ms=0
+  if [ -n "$csv_file" ] && [ -s "$csv_file" ]; then
+    # Extract receive latencies (us), convert to ms, sort, compute percentiles
+    local stats
+    stats=$(awk -F',' '$3 == "R" && $4 > 0 {printf "%.4f\n", $4 / 1000.0}' "$csv_file" \
+      | sort -n \
+      | awk '{vals[NR]=$1; sum+=$1}
+        END {
+          if (NR == 0) { print "0 0 0 0 0"; exit }
+          printf "%.2f %.2f %.2f %.2f %.2f\n",
+            vals[1], vals[int(NR*0.50)], vals[int(NR*0.75)], vals[int(NR*0.95)], vals[int(NR*0.99)]
+        }')
+    read -r min_ms median_ms p75_ms p95_ms p99_ms <<< "$stats"
+  fi
+
+  # Output in lavinmqperf format
+  echo "Summary:"
+  echo "  min: $min_ms"
+  echo "  median: $median_ms"
+  echo "  75th: $p75_ms"
+  echo "  95th: $p95_ms"
+  echo "  99th: $p99_ms"
+  echo "Average publish rate: $pub_rate"
+  echo "Average consume rate: $sub_rate"
+
+  rm -rf "$tmpdir"
+}
+
+# Main
+parse_args "$@"
+
+if [ "$COMMAND" != "throughput" ]; then
+  echo "Error: Unknown command '$COMMAND'. Only 'throughput' is supported."
+  exit 1
+fi
+
+if [ "$MEASURE_LATENCY" = true ]; then
+  run_latency
+else
+  run_throughput
+fi

--- a/scripts/run_mqtt_throughput_tests.sh
+++ b/scripts/run_mqtt_throughput_tests.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Script to run multiple MQTT throughput tests with different message sizes
+# Usage: ./run_mqtt_throughput_tests.sh <broker_ip> [size1,size2,size3,...] [duration] [broker_instance_type]
+
+set -e  # Exit on error
+
+# Function to format numbers with thousand separators
+format_number() {
+  local num="$1"
+  # Use printf with locale if available, otherwise use sed
+  LC_NUMERIC=en_US.UTF-8 printf "%'d" "$num" 2>/dev/null || \
+    echo "$num" | sed ':a;s/\B[0-9]\{3\}\>/,&/;ta'
+}
+
+BROKER_IP="${1}"
+SIZES="${2:-16,64,256,512,1024}"  # Default sizes if not provided
+DURATION="${3:-120}"  # Default duration 120 seconds if not provided
+BROKER_INSTANCE_TYPE="${4:-unknown}"  # Broker instance type for reporting
+OUTPUT_FILE="/home/ubuntu/mqtt_throughput_results.md"
+TEMP_CSV="/tmp/mqtt_throughput_results.csv"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [ -z "$BROKER_IP" ]; then
+  echo "Error: Broker IP not provided"
+  echo "Usage: $0 <broker_ip> [size1,size2,size3,...] [duration] [broker_instance_type]"
+  exit 1
+fi
+
+# Fetch LavinMQ version from broker API
+echo "Fetching LavinMQ version from broker..."
+OVERVIEW_RESPONSE=$(curl -s --request GET \
+  --url "http://$BROKER_IP:15672/api/overview" \
+  --header 'Accept: application/json' \
+  --header 'Authorization: Basic cGVyZnRlc3Q6cGVyZnRlc3Q=')
+
+# Parse lavinmq_version from JSON response
+LAVINMQ_VERSION=$(echo "$OVERVIEW_RESPONSE" | grep -o '"lavinmq_version":"[^"]*"' | cut -d'"' -f4)
+
+if [ -z "$LAVINMQ_VERSION" ]; then
+  LAVINMQ_VERSION="Unknown (failed to fetch)"
+fi
+
+echo "=========================================="
+echo "MQTT Throughput Test Runner"
+echo "=========================================="
+echo "Broker IP: $BROKER_IP"
+echo "Broker Instance Type: $BROKER_INSTANCE_TYPE"
+echo "LavinMQ Version: $LAVINMQ_VERSION"
+echo "Message Sizes: $SIZES"
+echo "Test Duration: $DURATION seconds"
+echo "Output File: $OUTPUT_FILE"
+echo "=========================================="
+echo ""
+
+# Initialize CSV temp file
+echo "Size,Pub_Rate,Con_Rate,Pub_BW,Con_BW" > "$TEMP_CSV"
+
+# Convert comma-separated sizes to array
+IFS=',' read -ra SIZE_ARRAY <<< "$SIZES"
+
+# Run test for each size
+for SIZE in "${SIZE_ARRAY[@]}"; do
+  echo "--------------------------------------"
+  echo "Testing with message size: $SIZE bytes"
+  echo "--------------------------------------"
+
+  # Run the throughput test via mqtt_bench.sh wrapper
+  echo "Running MQTT throughput test (size=$SIZE, duration=$DURATION seconds)..."
+  TEST_OUTPUT=$("$SCRIPT_DIR/mqtt_bench.sh" throughput -z "$DURATION" -x 1 -y 1 -s "$SIZE" \
+    --uri="mqtt://perftest:perftest@$BROKER_IP" 2>&1)
+
+  # Display the output
+  echo "$TEST_OUTPUT"
+
+  # Parse the results (same format as lavinmqperf)
+  PUB_RATE=$(echo "$TEST_OUTPUT" | grep "Average publish rate:" | awk '{print $4}')
+  CON_RATE=$(echo "$TEST_OUTPUT" | grep "Average consume rate:" | awk '{print $4}')
+
+  if [ -z "$PUB_RATE" ] || [ -z "$CON_RATE" ]; then
+    echo "Error: Failed to parse test results for size $SIZE"
+    exit 1
+  fi
+
+  # Calculate bandwidth in MiB/s: (size_bytes * msgs_per_sec) / (1024 * 1024)
+  PUB_BW=$(echo "scale=2; ($SIZE * $PUB_RATE) / (1024 * 1024)" | bc)
+  CON_BW=$(echo "scale=2; ($SIZE * $CON_RATE) / (1024 * 1024)" | bc)
+
+  echo "Results: Publish=$PUB_RATE msgs/s ($PUB_BW MiB/s), Consume=$CON_RATE msgs/s ($CON_BW MiB/s)"
+  echo ""
+
+  # Append to CSV
+  echo "$SIZE,$PUB_RATE,$CON_RATE,$PUB_BW,$CON_BW" >> "$TEMP_CSV"
+done
+
+echo "=========================================="
+echo "All tests completed!"
+echo "=========================================="
+echo ""
+
+# Generate markdown table
+echo "Generating markdown summary..."
+
+{
+  echo "# LavinMQ MQTT Throughput Test Results"
+  echo ""
+  echo "Test Date: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+  echo "Broker Instance Type: $BROKER_INSTANCE_TYPE"
+  echo "LavinMQ Version: $LAVINMQ_VERSION"
+  echo ""
+  echo "## Results"
+  echo ""
+  echo "- Protocol: MQTT v3.1.1"
+  echo "- Size: (bytes)"
+  echo "- Average publish/consume rates: (msgs/s)"
+  echo "- Publish/Consume bandwidth: (MiB/s)"
+  echo ""
+  echo "|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |"
+  echo "|------:|------------------:|------------------:|------------:|------------:|"
+
+  # Read CSV and format as markdown table (skip header)
+  tail -n +2 "$TEMP_CSV" | while IFS=',' read -r size pub_rate con_rate pub_bw con_bw; do
+    formatted_pub=$(format_number "$pub_rate")
+    formatted_con=$(format_number "$con_rate")
+    printf "| %5s | %17s | %17s | %11s | %11s |\n" "$size" "$formatted_pub" "$formatted_con" "$pub_bw" "$con_bw"
+  done
+
+  echo ""
+  echo "## Test Configuration"
+  echo ""
+  echo "- Protocol: MQTT v3.1.1"
+  echo "- Duration: $DURATION seconds (\`-z $DURATION\`)"
+  echo "- Producers: 1 (\`-x 1\`)"
+  echo "- Consumers: 1 (\`-y 1\`)"
+  echo "- Message sizes: $SIZES bytes"
+  echo ""
+} > "$OUTPUT_FILE"
+
+echo "Results saved to: $OUTPUT_FILE"
+echo ""
+echo "=========================================="
+echo "Summary:"
+echo "=========================================="
+cat "$OUTPUT_FILE"
+echo "=========================================="
+
+# Cleanup temp file
+rm -f "$TEMP_CSV"
+
+exit 0


### PR DESCRIPTION
Adds an AWS scenario for benchmarking LavinMQ's MQTT throughput using `emqtt-bench` (for throughput) and `mqttloader` (for latency). Adresses #27 

A new `mqtt_tools` Terraform module handles tool installation on load generator instances, and helper scripts automate running tests across multiple message sizes. Supporting infrastructure changes include opening MQTT port `1883`, fixing SSH key path expansion, and waiting for LavinMQ to be ready before creating test users.


Tested end-to-end on AWS with terraform apply, results below 

# LavinMQ MQTT Throughput Test Results

Test Date: 2026-04-14 08:01:46 UTC
Broker Instance Type: c8g.large
LavinMQ Version: 2.6.10

## Results

- Protocol: MQTT v3.1.1
- Size: (bytes)
- Average publish/consume rates: (msgs/s)
- Publish/Consume bandwidth: (MiB/s)

|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |
|------:|------------------:|------------------:|------------:|------------:|
|    16 |           232,865 |            93,482 |        3.55 |        1.42 |
|    64 |           192,628 |            96,282 |       11.75 |        5.87 |
|   256 |           212,758 |           106,382 |       51.94 |       25.97 |
|   512 |           257,936 |           128,947 |      125.94 |       62.96 |
|  1024 |           209,748 |           105,029 |      204.83 |      102.56 |

## Test Configuration

- Protocol: MQTT v3.1.1
- Duration: 120 seconds (`-z 120`)
- Producers: 1 (`-x 1`)
- Consumers: 1 (`-y 1`)
- Message sizes: 16,64,256,512,1024 bytes

