### PR TITLE
CI: Manual trigger parallel benchmark runs

### DIFF
--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -1,0 +1,156 @@
+name: Benchmark – Latency
+
+on:
+  workflow_call:
+    inputs:
+      lavinmq_version:
+        required: true
+        type: string
+
+env:
+  TF_VAR_aws_region: "us-east-1"
+  TF_VAR_aws_availability_zone: "us-east-1a"
+  TF_VAR_ubuntu_code_name: "noble"
+  TF_VAR_tag_created_by: "github-actions"
+  TF_VAR_tag_name: "lavinmq-benchmark-ci"
+  TF_VAR_message_sizes: "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
+  TF_VAR_num_runs: "3"
+  TF_VAR_broker_volume_size: "20"
+  TF_VAR_load_generator_volume_size: "8"
+  TF_VAR_lavinmq_version: ${{ inputs.lavinmq_version }}
+  TF_VAR_test_duration: "20"
+  TF_VAR_rate_limits: "[10, 100, 1000, 10000, 50000, 100000, 200000, 500000]"
+  TF_VAR_per_size_rate_limits: >-
+    {"16":[10,100,1000,5000,10000,50000,100000,250000,500000],
+     "64":[10,100,1000,5000,10000,50000,100000,250000,500000],
+     "256":[10,100,1000,5000,10000,50000,100000,250000],
+     "512":[10,100,1000,5000,10000,50000,100000],
+     "1024":[10,100,1000,5000,10000,50000],
+     "4096":[10,100,1000,5000,10000],
+     "16384":[10,100,1000,5000],
+     "65536":[10,100,1000]}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+jobs:
+  run:
+    name: "${{ matrix.broker }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # arm64 – load generator: c8g.large
+          - broker: t4g.micro
+            arch: arm64
+            load_generator: c8g.large
+          - broker: t4g.small
+            arch: arm64
+            load_generator: c8g.large
+          - broker: t4g.medium
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.medium
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.large
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.xlarge
+            arch: arm64
+            load_generator: c8g.large
+          - broker: c8g.large
+            arch: arm64
+            load_generator: c8g.large
+          - broker: i8g.large
+            arch: arm64
+            load_generator: c8g.large
+          # amd64 – load generator: c7a.large
+          - broker: c7a.large
+            arch: amd64
+            load_generator: c7a.large
+          - broker: i7i.large
+            arch: amd64
+            load_generator: c7a.large
+          - broker: z1d.large
+            arch: amd64
+            load_generator: c7a.large
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.9"
+
+      - name: Compute run-specific names
+        run: |
+          BROKER_SAFE="${{ matrix.broker }}"
+          BROKER_SAFE="${BROKER_SAFE//./-}"
+          SSH_KEY_NAME="benchmark-ci-latency-${{ github.run_id }}-${BROKER_SAFE}"
+          STATE_FILE="/tmp/tfstate-latency-${{ github.run_id }}-${BROKER_SAFE}.tfstate"
+          echo "broker_safe=${BROKER_SAFE}"    >> "$GITHUB_ENV"
+          echo "ssh_key_name=${SSH_KEY_NAME}"  >> "$GITHUB_ENV"
+          echo "state_file=${STATE_FILE}"      >> "$GITHUB_ENV"
+
+      - name: Write SSH public key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.BENCHMARK_SSH_PUBLIC_KEY }}" > ~/.ssh/benchmark_key.pub
+
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.BENCHMARK_SSH_PRIVATE_KEY }}
+
+      - name: Terraform init
+        working-directory: scenarios/aws/multiple_run_latency
+        run: terraform init
+
+      - name: Terraform apply
+        id: apply
+        working-directory: scenarios/aws/multiple_run_latency
+        run: |
+          terraform apply -auto-approve \
+            -state="${{ env.state_file }}" \
+            -var "ami_arch=${{ matrix.arch }}" \
+            -var "broker_instance_type=${{ matrix.broker }}" \
+            -var "broker_name=benchmark-broker-${{ env.broker_safe }}" \
+            -var "load_generator_instance_type=${{ matrix.load_generator }}" \
+            -var "load_generator_name=benchmark-loadgen-${{ env.broker_safe }}" \
+            -var "ssh_key_name=${{ env.ssh_key_name }}" \
+            -var "public_ssh_key=~/.ssh/benchmark_key.pub"
+
+      - name: Download results from load generator
+        id: download
+        if: steps.apply.outcome == 'success'
+        working-directory: scenarios/aws/multiple_run_latency
+        run: |
+          LG=$(terraform output -state="${{ env.state_file }}" -raw load_generator_public_dns)
+          scp -o StrictHostKeyChecking=accept-new \
+              -o UserKnownHostsFile=/tmp/known-hosts-latency-${{ env.broker_safe }} \
+              ubuntu@${LG}:/home/ubuntu/latency_results.md \
+              "${{ github.workspace }}/${{ env.broker_safe }}_latency.md"
+
+      - name: Upload artifact
+        if: steps.apply.outcome == 'success' && steps.download.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: latency-${{ matrix.broker }}
+          path: ${{ env.broker_safe }}_latency.md
+          if-no-files-found: error
+
+      - name: Terraform destroy
+        if: always()
+        working-directory: scenarios/aws/multiple_run_latency
+        run: |
+          terraform destroy -auto-approve \
+            -state="${{ env.state_file }}" \
+            -var "ami_arch=${{ matrix.arch }}" \
+            -var "broker_instance_type=${{ matrix.broker }}" \
+            -var "broker_name=benchmark-broker-${{ env.broker_safe }}" \
+            -var "load_generator_instance_type=${{ matrix.load_generator }}" \
+            -var "load_generator_name=benchmark-loadgen-${{ env.broker_safe }}" \
+            -var "ssh_key_name=${{ env.ssh_key_name }}" \
+            -var "public_ssh_key=~/.ssh/benchmark_key.pub"

--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -6,6 +6,17 @@ on:
       lavinmq_version:
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      lavinmq_version:
+        description: "LavinMQ version to benchmark (e.g. 2.7.0-rc.3 or 2.7.0)"
+        required: true
+        type: string
+      brokers:
+        description: "Comma-separated broker instance types to run (e.g. \"c8g.large\" or \"c8g.large,t4g.micro\"). Leave empty to run all."
+        required: false
+        type: string
+        default: ""
 
 env:
   TF_VAR_aws_region: "us-east-2"
@@ -33,50 +44,45 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    steps:
+      - name: Build matrix
+        id: filter
+        run: |
+          FULL_MATRIX='[
+            {"broker":"t4g.micro",  "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"t4g.small",  "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"t4g.medium", "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"r7g.medium", "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"r7g.large",  "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"r7g.xlarge", "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"c8g.large",  "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"i8g.large",  "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"c7a.large",  "arch":"amd64","load_generator":"c7a.large"},
+            {"broker":"i7i.large",  "arch":"amd64","load_generator":"c7a.large"},
+            {"broker":"z1d.large",  "arch":"amd64","load_generator":"c7a.large"}
+          ]'
+          BROKERS="${{ inputs.brokers }}"
+          if [ -z "$BROKERS" ]; then
+            MATRIX=$(echo "$FULL_MATRIX" | jq -c '{include: .}')
+          else
+            FILTER=$(echo "$BROKERS" | tr ',' '\n' | jq -R . | jq -s .)
+            MATRIX=$(echo "$FULL_MATRIX" | jq -c --argjson f "$FILTER" '{include: [.[] | select(.broker as $b | $f | index($b))]}')
+          fi
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
   run:
     name: "${{ matrix.broker }}"
+    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 180
 
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          # arm64 – load generator: c8g.large
-          - broker: t4g.micro
-            arch: arm64
-            load_generator: c8g.large
-          - broker: t4g.small
-            arch: arm64
-            load_generator: c8g.large
-          - broker: t4g.medium
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.medium
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.large
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.xlarge
-            arch: arm64
-            load_generator: c8g.large
-          - broker: c8g.large
-            arch: arm64
-            load_generator: c8g.large
-          - broker: i8g.large
-            arch: arm64
-            load_generator: c8g.large
-          # amd64 – load generator: c7a.large
-          - broker: c7a.large
-            arch: amd64
-            load_generator: c7a.large
-          - broker: i7i.large
-            arch: amd64
-            load_generator: c7a.large
-          - broker: z1d.large
-            arch: amd64
-            load_generator: c7a.large
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -13,7 +13,7 @@ env:
   TF_VAR_ubuntu_code_name: "noble"
   TF_VAR_tag_created_by: "github-actions"
   TF_VAR_tag_name: "lavinmq-benchmark-ci"
-  TF_VAR_message_sizes: "[16]" # "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
+  TF_VAR_message_sizes: "[16, 64]" # "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
   TF_VAR_num_runs: "3"
   TF_VAR_broker_volume_size: "20"
   TF_VAR_load_generator_volume_size: "8"
@@ -46,9 +46,9 @@ jobs:
           - broker: t4g.micro
             arch: arm64
             load_generator: c8g.large
-          # - broker: t4g.small
-          #   arch: arm64
-          #   load_generator: c8g.large
+          - broker: t4g.small
+            arch: arm64
+            load_generator: c8g.large
           # - broker: t4g.medium
           #   arch: arm64
           #   load_generator: c8g.large

--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -8,12 +8,12 @@ on:
         type: string
 
 env:
-  TF_VAR_aws_region: "us-east-1"
-  TF_VAR_aws_availability_zone: "us-east-1a"
+  TF_VAR_aws_region: "us-east-2"
+  TF_VAR_aws_availability_zone: "us-east-2a"
   TF_VAR_ubuntu_code_name: "noble"
   TF_VAR_tag_created_by: "github-actions"
   TF_VAR_tag_name: "lavinmq-benchmark-ci"
-  TF_VAR_message_sizes: "[16, 64]" # "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
+  TF_VAR_message_sizes: "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
   TF_VAR_num_runs: "3"
   TF_VAR_broker_volume_size: "20"
   TF_VAR_load_generator_volume_size: "8"
@@ -49,34 +49,34 @@ jobs:
           - broker: t4g.small
             arch: arm64
             load_generator: c8g.large
-          # - broker: t4g.medium
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # - broker: r7g.medium
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # - broker: r7g.large
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # - broker: r7g.xlarge
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # - broker: c8g.large
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # - broker: i8g.large
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # # amd64 – load generator: c7a.large
-          # - broker: c7a.large
-          #   arch: amd64
-          #   load_generator: c7a.large
-          # - broker: i7i.large
-          #   arch: amd64
-          #   load_generator: c7a.large
-          # - broker: z1d.large
-          #   arch: amd64
-          #   load_generator: c7a.large
+          - broker: t4g.medium
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.medium
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.large
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.xlarge
+            arch: arm64
+            load_generator: c8g.large
+          - broker: c8g.large
+            arch: arm64
+            load_generator: c8g.large
+          - broker: i8g.large
+            arch: arm64
+            load_generator: c8g.large
+          # amd64 – load generator: c7a.large
+          - broker: c7a.large
+            arch: amd64
+            load_generator: c7a.large
+          - broker: i7i.large
+            arch: amd64
+            load_generator: c7a.large
+          - broker: z1d.large
+            arch: amd64
+            load_generator: c7a.large
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -6,6 +6,10 @@ on:
       lavinmq_version:
         required: true
         type: string
+      brokers:
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       lavinmq_version:

--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -79,9 +79,9 @@ jobs:
             load_generator: c7a.large
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: "~1.9"
 
@@ -102,7 +102,7 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_PUBKEY" > ~/.ssh/benchmark_key.pub
 
-      - uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.BENCHMARK_SSH_PRIVATE_KEY }}
 
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload artifact
         if: steps.apply.outcome == 'success' && steps.download.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: latency-${{ matrix.broker }}
           path: ${{ env.broker_safe }}_latency.md

--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -96,11 +96,13 @@ jobs:
           echo "state_file=${STATE_FILE}"      >> "$GITHUB_ENV"
 
       - name: Write SSH public key
+        env:
+          SSH_PUBKEY: ${{ secrets.BENCHMARK_SSH_PUBLIC_KEY }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.BENCHMARK_SSH_PUBLIC_KEY }}" > ~/.ssh/benchmark_key.pub
+          printf '%s\n' "$SSH_PUBKEY" > ~/.ssh/benchmark_key.pub
 
-      - uses: webfactory/ssh-agent@v0.9.0
+      - uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
         with:
           ssh-private-key: ${{ secrets.BENCHMARK_SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -13,7 +13,7 @@ env:
   TF_VAR_ubuntu_code_name: "noble"
   TF_VAR_tag_created_by: "github-actions"
   TF_VAR_tag_name: "lavinmq-benchmark-ci"
-  TF_VAR_message_sizes: "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
+  TF_VAR_message_sizes: "[16]" # "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
   TF_VAR_num_runs: "3"
   TF_VAR_broker_volume_size: "20"
   TF_VAR_load_generator_volume_size: "8"
@@ -46,37 +46,37 @@ jobs:
           - broker: t4g.micro
             arch: arm64
             load_generator: c8g.large
-          - broker: t4g.small
-            arch: arm64
-            load_generator: c8g.large
-          - broker: t4g.medium
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.medium
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.large
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.xlarge
-            arch: arm64
-            load_generator: c8g.large
-          - broker: c8g.large
-            arch: arm64
-            load_generator: c8g.large
-          - broker: i8g.large
-            arch: arm64
-            load_generator: c8g.large
-          # amd64 – load generator: c7a.large
-          - broker: c7a.large
-            arch: amd64
-            load_generator: c7a.large
-          - broker: i7i.large
-            arch: amd64
-            load_generator: c7a.large
-          - broker: z1d.large
-            arch: amd64
-            load_generator: c7a.large
+          # - broker: t4g.small
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # - broker: t4g.medium
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # - broker: r7g.medium
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # - broker: r7g.large
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # - broker: r7g.xlarge
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # - broker: c8g.large
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # - broker: i8g.large
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # # amd64 – load generator: c7a.large
+          # - broker: c7a.large
+          #   arch: amd64
+          #   load_generator: c7a.large
+          # - broker: i7i.large
+          #   arch: amd64
+          #   load_generator: c7a.large
+          # - broker: z1d.large
+          #   arch: amd64
+          #   load_generator: c7a.large
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -33,12 +33,12 @@ jobs:
       matrix:
         include:
           # arm64 – load generator: c8g.large
-          - broker: t4g.micro
-            arch: arm64
-            load_generator: c8g.large
-          # - broker: t4g.small
+          # - broker: t4g.micro
           #   arch: arm64
           #   load_generator: c8g.large
+          - broker: t4g.small
+            arch: arm64
+            load_generator: c8g.large
           # - broker: t4g.medium
           #   arch: arm64
           #   load_generator: c8g.large

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -69,9 +69,9 @@ jobs:
           #   load_generator: c7a.large
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: "~1.9"
 
@@ -92,7 +92,7 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_PUBKEY" > ~/.ssh/benchmark_key.pub
 
-      - uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.BENCHMARK_SSH_PRIVATE_KEY }}
 
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload artifact
         if: steps.apply.outcome == 'success' && steps.download.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: throughput-${{ matrix.broker }}
           path: ${{ env.broker_safe }}_throughput.md

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -13,7 +13,7 @@ env:
   TF_VAR_ubuntu_code_name: "noble"
   TF_VAR_tag_created_by: "github-actions"
   TF_VAR_tag_name: "lavinmq-benchmark-ci"
-  TF_VAR_message_sizes: "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
+  TF_VAR_message_sizes: "[16, 64]" # "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
   TF_VAR_num_runs: "3"
   TF_VAR_broker_volume_size: "20"
   TF_VAR_load_generator_volume_size: "8"
@@ -39,34 +39,34 @@ jobs:
           - broker: t4g.small
             arch: arm64
             load_generator: c8g.large
-          - broker: t4g.medium
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.medium
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.large
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.xlarge
-            arch: arm64
-            load_generator: c8g.large
-          - broker: c8g.large
-            arch: arm64
-            load_generator: c8g.large
-          - broker: i8g.large
-            arch: arm64
-            load_generator: c8g.large
-          # amd64 – load generator: c7a.large
-          - broker: c7a.large
-            arch: amd64
-            load_generator: c7a.large
-          - broker: i7i.large
-            arch: amd64
-            load_generator: c7a.large
-          - broker: z1d.large
-            arch: amd64
-            load_generator: c7a.large
+          # - broker: t4g.medium
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # - broker: r7g.medium
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # - broker: r7g.large
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # - broker: r7g.xlarge
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # - broker: c8g.large
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # - broker: i8g.large
+          #   arch: arm64
+          #   load_generator: c8g.large
+          # # amd64 – load generator: c7a.large
+          # - broker: c7a.large
+          #   arch: amd64
+          #   load_generator: c7a.large
+          # - broker: i7i.large
+          #   arch: amd64
+          #   load_generator: c7a.large
+          # - broker: z1d.large
+          #   arch: amd64
+          #   load_generator: c7a.large
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -6,6 +6,17 @@ on:
       lavinmq_version:
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      lavinmq_version:
+        description: "LavinMQ version to benchmark (e.g. 2.7.0-rc.3 or 2.7.0)"
+        required: true
+        type: string
+      brokers:
+        description: "Comma-separated broker instance types to run (e.g. \"c8g.large\" or \"c8g.large,t4g.micro\"). Leave empty to run all."
+        required: false
+        type: string
+        default: ""
 
 env:
   TF_VAR_aws_region: "us-east-2"
@@ -23,50 +34,45 @@ env:
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.filter.outputs.matrix }}
+    steps:
+      - name: Build matrix
+        id: filter
+        run: |
+          FULL_MATRIX='[
+            {"broker":"t4g.micro",  "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"t4g.small",  "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"t4g.medium", "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"r7g.medium", "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"r7g.large",  "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"r7g.xlarge", "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"c8g.large",  "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"i8g.large",  "arch":"arm64","load_generator":"c8g.large"},
+            {"broker":"c7a.large",  "arch":"amd64","load_generator":"c7a.large"},
+            {"broker":"i7i.large",  "arch":"amd64","load_generator":"c7a.large"},
+            {"broker":"z1d.large",  "arch":"amd64","load_generator":"c7a.large"}
+          ]'
+          BROKERS="${{ inputs.brokers }}"
+          if [ -z "$BROKERS" ]; then
+            MATRIX=$(echo "$FULL_MATRIX" | jq -c '{include: .}')
+          else
+            FILTER=$(echo "$BROKERS" | tr ',' '\n' | jq -R . | jq -s .)
+            MATRIX=$(echo "$FULL_MATRIX" | jq -c --argjson f "$FILTER" '{include: [.[] | select(.broker as $b | $f | index($b))]}')
+          fi
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
   run:
     name: "${{ matrix.broker }}"
+    needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          # arm64 – load generator: c8g.large
-          - broker: t4g.micro
-            arch: arm64
-            load_generator: c8g.large
-          - broker: t4g.small
-            arch: arm64
-            load_generator: c8g.large
-          - broker: t4g.medium
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.medium
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.large
-            arch: arm64
-            load_generator: c8g.large
-          - broker: r7g.xlarge
-            arch: arm64
-            load_generator: c8g.large
-          - broker: c8g.large
-            arch: arm64
-            load_generator: c8g.large
-          - broker: i8g.large
-            arch: arm64
-            load_generator: c8g.large
-          # amd64 – load generator: c7a.large
-          - broker: c7a.large
-            arch: amd64
-            load_generator: c7a.large
-          - broker: i7i.large
-            arch: amd64
-            load_generator: c7a.large
-          - broker: z1d.large
-            arch: amd64
-            load_generator: c7a.large
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -8,12 +8,12 @@ on:
         type: string
 
 env:
-  TF_VAR_aws_region: "us-east-1"
-  TF_VAR_aws_availability_zone: "us-east-1a"
+  TF_VAR_aws_region: "us-east-2"
+  TF_VAR_aws_availability_zone: "us-east-2a"
   TF_VAR_ubuntu_code_name: "noble"
   TF_VAR_tag_created_by: "github-actions"
   TF_VAR_tag_name: "lavinmq-benchmark-ci"
-  TF_VAR_message_sizes: "[16, 64]" # "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
+  TF_VAR_message_sizes: "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
   TF_VAR_num_runs: "3"
   TF_VAR_broker_volume_size: "20"
   TF_VAR_load_generator_volume_size: "8"
@@ -39,34 +39,34 @@ jobs:
           - broker: t4g.small
             arch: arm64
             load_generator: c8g.large
-          # - broker: t4g.medium
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # - broker: r7g.medium
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # - broker: r7g.large
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # - broker: r7g.xlarge
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # - broker: c8g.large
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # - broker: i8g.large
-          #   arch: arm64
-          #   load_generator: c8g.large
-          # # amd64 – load generator: c7a.large
-          # - broker: c7a.large
-          #   arch: amd64
-          #   load_generator: c7a.large
-          # - broker: i7i.large
-          #   arch: amd64
-          #   load_generator: c7a.large
-          # - broker: z1d.large
-          #   arch: amd64
-          #   load_generator: c7a.large
+          - broker: t4g.medium
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.medium
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.large
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.xlarge
+            arch: arm64
+            load_generator: c8g.large
+          - broker: c8g.large
+            arch: arm64
+            load_generator: c8g.large
+          - broker: i8g.large
+            arch: arm64
+            load_generator: c8g.large
+          # amd64 – load generator: c7a.large
+          - broker: c7a.large
+            arch: amd64
+            load_generator: c7a.large
+          - broker: i7i.large
+            arch: amd64
+            load_generator: c7a.large
+          - broker: z1d.large
+            arch: amd64
+            load_generator: c7a.large
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -6,6 +6,10 @@ on:
       lavinmq_version:
         required: true
         type: string
+      brokers:
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       lavinmq_version:

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -36,9 +36,9 @@ jobs:
           - broker: t4g.micro
             arch: arm64
             load_generator: c8g.large
-          - broker: t4g.small
-            arch: arm64
-            load_generator: c8g.large
+          # - broker: t4g.small
+          #   arch: arm64
+          #   load_generator: c8g.large
           # - broker: t4g.medium
           #   arch: arm64
           #   load_generator: c8g.large

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -33,9 +33,9 @@ jobs:
       matrix:
         include:
           # arm64 – load generator: c8g.large
-          # - broker: t4g.micro
-          #   arch: arm64
-          #   load_generator: c8g.large
+          - broker: t4g.micro
+            arch: arm64
+            load_generator: c8g.large
           - broker: t4g.small
             arch: arm64
             load_generator: c8g.large

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -86,11 +86,13 @@ jobs:
           echo "state_file=${STATE_FILE}"      >> "$GITHUB_ENV"
 
       - name: Write SSH public key
+        env:
+          SSH_PUBKEY: ${{ secrets.BENCHMARK_SSH_PUBLIC_KEY }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.BENCHMARK_SSH_PUBLIC_KEY }}" > ~/.ssh/benchmark_key.pub
+          printf '%s\n' "$SSH_PUBKEY" > ~/.ssh/benchmark_key.pub
 
-      - uses: webfactory/ssh-agent@v0.9.0
+      - uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
         with:
           ssh-private-key: ${{ secrets.BENCHMARK_SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -1,0 +1,146 @@
+name: Benchmark – Throughput
+
+on:
+  workflow_call:
+    inputs:
+      lavinmq_version:
+        required: true
+        type: string
+
+env:
+  TF_VAR_aws_region: "us-east-1"
+  TF_VAR_aws_availability_zone: "us-east-1a"
+  TF_VAR_ubuntu_code_name: "noble"
+  TF_VAR_tag_created_by: "github-actions"
+  TF_VAR_tag_name: "lavinmq-benchmark-ci"
+  TF_VAR_message_sizes: "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
+  TF_VAR_num_runs: "3"
+  TF_VAR_broker_volume_size: "20"
+  TF_VAR_load_generator_volume_size: "8"
+  TF_VAR_lavinmq_version: ${{ inputs.lavinmq_version }}
+  TF_VAR_test_duration: "60"
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+jobs:
+  run:
+    name: "${{ matrix.broker }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # arm64 – load generator: c8g.large
+          - broker: t4g.micro
+            arch: arm64
+            load_generator: c8g.large
+          - broker: t4g.small
+            arch: arm64
+            load_generator: c8g.large
+          - broker: t4g.medium
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.medium
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.large
+            arch: arm64
+            load_generator: c8g.large
+          - broker: r7g.xlarge
+            arch: arm64
+            load_generator: c8g.large
+          - broker: c8g.large
+            arch: arm64
+            load_generator: c8g.large
+          - broker: i8g.large
+            arch: arm64
+            load_generator: c8g.large
+          # amd64 – load generator: c7a.large
+          - broker: c7a.large
+            arch: amd64
+            load_generator: c7a.large
+          - broker: i7i.large
+            arch: amd64
+            load_generator: c7a.large
+          - broker: z1d.large
+            arch: amd64
+            load_generator: c7a.large
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.9"
+
+      - name: Compute run-specific names
+        run: |
+          BROKER_SAFE="${{ matrix.broker }}"
+          BROKER_SAFE="${BROKER_SAFE//./-}"
+          SSH_KEY_NAME="benchmark-ci-throughput-${{ github.run_id }}-${BROKER_SAFE}"
+          STATE_FILE="/tmp/tfstate-throughput-${{ github.run_id }}-${BROKER_SAFE}.tfstate"
+          echo "broker_safe=${BROKER_SAFE}"    >> "$GITHUB_ENV"
+          echo "ssh_key_name=${SSH_KEY_NAME}"  >> "$GITHUB_ENV"
+          echo "state_file=${STATE_FILE}"      >> "$GITHUB_ENV"
+
+      - name: Write SSH public key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.BENCHMARK_SSH_PUBLIC_KEY }}" > ~/.ssh/benchmark_key.pub
+
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.BENCHMARK_SSH_PRIVATE_KEY }}
+
+      - name: Terraform init
+        working-directory: scenarios/aws/multiple_run_throughput
+        run: terraform init
+
+      - name: Terraform apply
+        id: apply
+        working-directory: scenarios/aws/multiple_run_throughput
+        run: |
+          terraform apply -auto-approve \
+            -state="${{ env.state_file }}" \
+            -var "ami_arch=${{ matrix.arch }}" \
+            -var "broker_instance_type=${{ matrix.broker }}" \
+            -var "broker_name=benchmark-broker-${{ env.broker_safe }}" \
+            -var "load_generator_instance_type=${{ matrix.load_generator }}" \
+            -var "load_generator_name=benchmark-loadgen-${{ env.broker_safe }}" \
+            -var "ssh_key_name=${{ env.ssh_key_name }}" \
+            -var "public_ssh_key=~/.ssh/benchmark_key.pub"
+
+      - name: Download results from load generator
+        id: download
+        if: steps.apply.outcome == 'success'
+        working-directory: scenarios/aws/multiple_run_throughput
+        run: |
+          LG=$(terraform output -state="${{ env.state_file }}" -raw load_generator_public_dns)
+          scp -o StrictHostKeyChecking=accept-new \
+              -o UserKnownHostsFile=/tmp/known-hosts-throughput-${{ env.broker_safe }} \
+              ubuntu@${LG}:/home/ubuntu/throughput_results.md \
+              "${{ github.workspace }}/${{ env.broker_safe }}_throughput.md"
+
+      - name: Upload artifact
+        if: steps.apply.outcome == 'success' && steps.download.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: throughput-${{ matrix.broker }}
+          path: ${{ env.broker_safe }}_throughput.md
+          if-no-files-found: error
+
+      - name: Terraform destroy
+        if: always()
+        working-directory: scenarios/aws/multiple_run_throughput
+        run: |
+          terraform destroy -auto-approve \
+            -state="${{ env.state_file }}" \
+            -var "ami_arch=${{ matrix.arch }}" \
+            -var "broker_instance_type=${{ matrix.broker }}" \
+            -var "broker_name=benchmark-broker-${{ env.broker_safe }}" \
+            -var "load_generator_instance_type=${{ matrix.load_generator }}" \
+            -var "load_generator_name=benchmark-loadgen-${{ env.broker_safe }}" \
+            -var "ssh_key_name=${{ env.ssh_key_name }}" \
+            -var "public_ssh_key=~/.ssh/benchmark_key.pub"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,13 +52,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download latency artifacts
         if: needs.latency.result == 'success' || needs.latency.result == 'failure'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: latency-*
           path: raw-results/latency
@@ -66,7 +66,7 @@ jobs:
 
       - name: Download throughput artifacts
         if: needs.throughput.result == 'success' || needs.throughput.result == 'failure'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: throughput-*
           path: raw-results/throughput

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,11 @@ on:
           - all
           - latency
           - throughput
+      brokers:
+        description: "Comma-separated broker instance types to run (e.g. \"c8g.large\" or \"c8g.large,t4g.micro\"). Leave empty to run all."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -27,6 +32,7 @@ jobs:
     uses: ./.github/workflows/benchmark-latency.yml
     with:
       lavinmq_version: ${{ inputs.lavinmq_version }}
+      brokers: ${{ inputs.brokers }}
     secrets: inherit
 
   throughput:
@@ -35,6 +41,7 @@ jobs:
     uses: ./.github/workflows/benchmark-throughput.yml
     with:
       lavinmq_version: ${{ inputs.lavinmq_version }}
+      brokers: ${{ inputs.brokers }}
     secrets: inherit
 
   # --------------------------------------------------------------------------

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Create Pull Request
         if: env.has_results == 'true'
-        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
           draft: true # Temporary draft status

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -81,7 +81,7 @@ jobs:
             echo "has_results=true" >> "$GITHUB_ENV"
           fi
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: env.has_results == 'true'
         with:
           python-version: "3.x"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,166 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      lavinmq_version:
+        description: "LavinMQ version to benchmark (e.g. 2.7.0-rc.3 or 2.7.0)"
+        required: true
+        type: string
+      scenarios:
+        description: "Which scenarios to run"
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - latency
+          - throughput
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  latency:
+    name: "Latency"
+    if: inputs.scenarios == 'all' || inputs.scenarios == 'latency'
+    uses: ./.github/workflows/benchmark-latency.yml
+    with:
+      lavinmq_version: ${{ inputs.lavinmq_version }}
+    secrets: inherit
+
+  throughput:
+    name: "Throughput"
+    if: inputs.scenarios == 'all' || inputs.scenarios == 'throughput'
+    uses: ./.github/workflows/benchmark-throughput.yml
+    with:
+      lavinmq_version: ${{ inputs.lavinmq_version }}
+    secrets: inherit
+
+  # --------------------------------------------------------------------------
+  # AGGREGATE & PR
+  # --------------------------------------------------------------------------
+  aggregate:
+    name: "Aggregate results & open PR"
+    needs: [latency, throughput]
+    # Run if at least one scenario finished (not cancelled, not skipped due to
+    # scenario selection), even if some matrix jobs within it failed.
+    if: |
+      always() && !cancelled() &&
+      (needs.latency.result == 'success' || needs.latency.result == 'failure' ||
+       needs.throughput.result == 'success' || needs.throughput.result == 'failure')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download latency artifacts
+        if: needs.latency.result == 'success' || needs.latency.result == 'failure'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: latency-*
+          path: raw-results/latency
+          merge-multiple: false
+
+      - name: Download throughput artifacts
+        if: needs.throughput.result == 'success' || needs.throughput.result == 'failure'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: throughput-*
+          path: raw-results/throughput
+          merge-multiple: false
+
+      - name: Check that at least one artifact was downloaded
+        run: |
+          if [ -z "$(find raw-results -name '*.md' 2>/dev/null)" ]; then
+            echo "No result files found – all benchmark jobs failed. Skipping PR."
+            echo "has_results=false" >> "$GITHUB_ENV"
+          else
+            echo "has_results=true" >> "$GITHUB_ENV"
+          fi
+
+      - uses: actions/setup-python@v5
+        if: env.has_results == 'true'
+        with:
+          python-version: "3.x"
+
+      - name: Aggregate results
+        if: env.has_results == 'true'
+        run: |
+          python scripts/aggregate_results.py \
+            --version "${{ inputs.lavinmq_version }}" \
+            --latency-dir    raw-results/latency \
+            --throughput-dir raw-results/throughput \
+            --output-dir     results
+
+      - name: Commit and push results branch
+        if: env.has_results == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="v${{ inputs.lavinmq_version }}"
+          BRANCH="results/${VERSION}"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin
+          if git ls-remote --exit-code --heads origin "${BRANCH}" > /dev/null 2>&1; then
+            git checkout "${BRANCH}"
+          else
+            git checkout -b "${BRANCH}"
+          fi
+
+          git add results/
+          if ! git diff --cached --quiet; then
+            git commit -m "Add ${{ inputs.scenarios }} benchmark results for ${VERSION} [run ${{ github.run_id }}]"
+            git push origin "${BRANCH}"
+          else
+            echo "No new result files to commit."
+          fi
+
+          EXISTING=$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number')
+          if [ -z "$EXISTING" ]; then
+            gh pr create \
+              --title "Benchmark results: ${VERSION}" \
+              --body "Automated benchmark results for LavinMQ **${VERSION}**.
+
+          Run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          Scenarios: \`${{ inputs.scenarios }}\`
+
+          Results are in \`results/${VERSION}/\`. Additional scenarios can be added to this PR by triggering new runs with the same version." \
+              --base main \
+              --head "${BRANCH}"
+          else
+            echo "PR #${EXISTING} already exists for ${BRANCH} – results pushed to existing branch."
+          fi
+
+  # --------------------------------------------------------------------------
+  # SUMMARY
+  # --------------------------------------------------------------------------
+  summary:
+    name: "Workflow summary"
+    needs: [latency, throughput, aggregate]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Write job summary
+        run: |
+          VERSION="v${{ inputs.lavinmq_version }}"
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## Benchmark run: ${VERSION}
+
+          | | Result |
+          |---|---|
+          | LavinMQ version | \`${VERSION}\` |
+          | Scenarios | \`${{ inputs.scenarios }}\` |
+          | Latency jobs | ${{ needs.latency.result || 'skipped' }} |
+          | Throughput jobs | ${{ needs.throughput.result || 'skipped' }} |
+          | Aggregate & PR | ${{ needs.aggregate.result }} |
+
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EOF

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   latency:
@@ -96,47 +95,29 @@ jobs:
             --throughput-dir raw-results/throughput \
             --output-dir     results
 
-      - name: Commit and push results branch
+      - name: Configure git
         if: env.has_results == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="v${{ inputs.lavinmq_version }}"
-          BRANCH="results/${VERSION}"
-
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git fetch origin
-          if git ls-remote --exit-code --heads origin "${BRANCH}" > /dev/null 2>&1; then
-            git checkout "${BRANCH}"
-          else
-            git checkout -b "${BRANCH}"
-          fi
+      - name: Create Pull Request
+        if: env.has_results == 'true'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.PAT }}
+          draft: true # Temporary draft status
+          branch: results/v${{ inputs.lavinmq_version }}
+          base: main
+          title: "Benchmark results: v${{ inputs.lavinmq_version }}"
+          commit-message: "Add ${{ inputs.scenarios }} benchmark results for v${{ inputs.lavinmq_version }} [run ${{ github.run_id }}]"
+          body: |
+            Automated benchmark results for LavinMQ **v${{ inputs.lavinmq_version }}**.
 
-          git add results/
-          if ! git diff --cached --quiet; then
-            git commit -m "Add ${{ inputs.scenarios }} benchmark results for ${VERSION} [run ${{ github.run_id }}]"
-            git push origin "${BRANCH}"
-          else
-            echo "No new result files to commit."
-          fi
+            Run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            Scenarios: `${{ inputs.scenarios }}`
 
-          EXISTING=$(gh pr list --head "${BRANCH}" --json number --jq '.[0].number')
-          if [ -z "$EXISTING" ]; then
-            gh pr create \
-              --title "Benchmark results: ${VERSION}" \
-              --body "Automated benchmark results for LavinMQ **${VERSION}**.
-
-          Run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          Scenarios: \`${{ inputs.scenarios }}\`
-
-          Results are in \`results/${VERSION}/\`. Additional scenarios can be added to this PR by triggering new runs with the same version." \
-              --base main \
-              --head "${BRANCH}"
-          else
-            echo "PR #${EXISTING} already exists for ${BRANCH} – results pushed to existing branch."
-          fi
+            Results are in `results/v${{ inputs.lavinmq_version }}/`. Additional scenarios can be added to this PR by triggering new runs with the same version.
 
   # --------------------------------------------------------------------------
   # SUMMARY

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -86,6 +86,14 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Restore existing results from PR branch
+        if: env.has_results == 'true'
+        run: |
+          BRANCH="results/v${{ inputs.lavinmq_version }}"
+          if git fetch origin "${BRANCH}" 2>/dev/null; then
+            git checkout "origin/${BRANCH}" -- results/ 2>/dev/null || true
+          fi
+
       - name: Aggregate results
         if: env.has_results == 'true'
         run: |
@@ -100,6 +108,10 @@ jobs:
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Clean up raw results
+        if: env.has_results == 'true'
+        run: rm -rf raw-results/
 
       - name: Create Pull Request
         if: env.has_results == 'true'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -106,6 +106,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.PAT }}
+          add-paths: results/
           draft: true # Temporary draft status
           branch: results/v${{ inputs.lavinmq_version }}
           base: main

--- a/README.md
+++ b/README.md
@@ -35,22 +35,26 @@ bandwidth, stored on the load generator and displayed as Terraform output.
 Variables can be supplied in three ways:
 
 **`terraform.auto.tfvars`** — loaded automatically by Terraform:
+
 ```shell
 terraform apply
 ```
 
 **`terraform.tfvars`** — loaded explicitly:
+
 ```shell
 terraform apply -var-file="terraform.tfvars"
 ```
 
 **`.env` file via [dotenv](https://github.com/bkeepers/dotenv)** — environment variables prefixed
 with `TF_VAR_`:
+
 ```shell
 dotenv terraform apply
 ```
 
 Use the templates in `modules/providers/aws/variables_template/` as a starting point:
+
 - `terraform_tfvars.txt` — for `.tfvars` files
 - `env.txt` — for `.env` files
 
@@ -60,6 +64,48 @@ AWS credentials must be set as environment variables regardless of the method us
 export AWS_ACCESS_KEY=***
 export AWS_SECRET_KEY=***
 ```
+
+## CI / Parallel Benchmarks
+
+The [Benchmark](../../actions/workflows/benchmark.yml) GitHub Actions workflow provisions
+infrastructure, runs benchmarks across all supported instance types in parallel, aggregates the
+results into markdown summary files, and opens a pull request against `main` with the results
+committed to a `results/v{version}` branch.
+
+### Required secrets
+
+| Secret | Description |
+|---|---|
+| `AWS_ACCESS_KEY_ID` | AWS access key with EC2 / VPC create permissions |
+| `AWS_SECRET_ACCESS_KEY` | Corresponding AWS secret key |
+| `BENCHMARK_SSH_PRIVATE_KEY` | Private half of the key pair used by Terraform to connect to instances |
+| `BENCHMARK_SSH_PUBLIC_KEY` | Public half of the key pair (deployed to instances) |
+
+### Triggering a run
+
+**Via the GitHub UI:** go to **Actions → Benchmark → Run workflow**, fill in the version and pick a scenario.
+
+**Via the GitHub CLI:**
+
+```shell
+# Run both latency and throughput benchmarks
+gh workflow run benchmark.yml \
+  -f lavinmq_version=2.7.0 \
+  -f scenarios=all
+
+# Latency only
+gh workflow run benchmark.yml \
+  -f lavinmq_version=2.7.0 \
+  -f scenarios=latency
+
+# Throughput only
+gh workflow run benchmark.yml \
+  -f lavinmq_version=2.7.0 \
+  -f scenarios=throughput
+```
+
+Results are committed to `results/v{version}/` and a pull request is created (or updated if one
+already exists for that version).
 
 ## Logging
 

--- a/README.md
+++ b/README.md
@@ -72,15 +72,6 @@ infrastructure, runs benchmarks across all supported instance types in parallel,
 results into markdown summary files, and opens a pull request against `main` with the results
 committed to a `results/v{version}` branch.
 
-### Required secrets
-
-| Secret | Description |
-|---|---|
-| `AWS_ACCESS_KEY_ID` | AWS access key with EC2 / VPC create permissions |
-| `AWS_SECRET_ACCESS_KEY` | Corresponding AWS secret key |
-| `BENCHMARK_SSH_PRIVATE_KEY` | Private half of the key pair used by Terraform to connect to instances |
-| `BENCHMARK_SSH_PUBLIC_KEY` | Public half of the key pair (deployed to instances) |
-
 ### Triggering a run
 
 **Via the GitHub UI:** go to **Actions → Benchmark → Run workflow**, fill in the version and pick a scenario.
@@ -88,7 +79,7 @@ committed to a `results/v{version}` branch.
 **Via the GitHub CLI:**
 
 ```shell
-# Run both latency and throughput benchmarks
+# Run both latency and throughput benchmarks for all instance types
 gh workflow run benchmark.yml \
   -f lavinmq_version=2.7.0 \
   -f scenarios=all
@@ -106,6 +97,29 @@ gh workflow run benchmark.yml \
 
 Results are committed to `results/v{version}/` and a pull request is created (or updated if one
 already exists for that version).
+
+### Re-running specific broker instance types
+
+All three workflows accept an optional `brokers` input — a comma-separated list of broker instance
+types to run. When omitted or empty, all instance types are benchmarked. This is useful for
+re-running a single instance type that failed without triggering the full suite.
+
+```shell
+# Re-run latency benchmark for a single instance type
+gh workflow run benchmark.yml \
+  -f lavinmq_version=2.7.0 \
+  -f scenarios=latency \
+  -f brokers="c8g.large"
+
+# Re-run latency benchmark for multiple specific instance types
+gh workflow run benchmark.yml \
+  -f lavinmq_version=2.7.0 \
+  -f scenarios=latency \
+  -f brokers="c8g.large,t4g.medium"
+```
+
+The individual `benchmark-latency.yml` and `benchmark-throughput.yml` workflows can also be
+triggered directly in the same way if you want to skip the aggregate/PR step.
 
 ## Logging
 

--- a/modules/providers/aws/instance/instance.tf
+++ b/modules/providers/aws/instance/instance.tf
@@ -23,22 +23,10 @@ resource "aws_instance" "instance" {
   }
 }
 
-resource "aws_eip" "this" {
-  domain = "vpc"
-
-  instance                  = aws_instance.instance.id
-  associate_with_private_ip = aws_instance.instance.private_ip
-
-  tags = {
-    Name      = var.tag_name
-    CreatedBy = var.tag_created_by
-  }
-}
-
 output "public_dns" {
-  value = aws_eip.this.public_dns
+  value = aws_instance.instance.public_dns
 }
 
 output "private_ip" {
-  value = aws_eip.this.private_ip
+  value = aws_instance.instance.private_ip
 }

--- a/scenarios/aws/multiple_run_latency/defaults.env
+++ b/scenarios/aws/multiple_run_latency/defaults.env
@@ -1,0 +1,23 @@
+# Shared non-secret defaults for the multiple_run_latency scenario.
+# Tracked in git. Override any value in your local .env file.
+# Usage (local): dotenv -f defaults.env -f .env -- terraform apply
+# Usage (CI):    loaded automatically by the benchmark workflow.
+
+# AWS region
+TF_VAR_aws_region="us-east-1"
+TF_VAR_aws_availability_zone="us-east-1a"
+
+# AMI / OS
+TF_VAR_ubuntu_code_name="noble"
+
+# Test configuration
+TF_VAR_message_sizes=[16, 64, 256, 512, 1024, 4096, 16384, 65536]
+TF_VAR_rate_limits=[10, 100, 1000, 10000, 50000, 100000, 200000, 500000]
+# Per-size rate limits: calibrated so no rate exceeds the weakest instance's measured max throughput.
+TF_VAR_per_size_rate_limits={"16":[10,100,1000,5000,10000,50000,100000,250000,500000],"64":[10,100,1000,5000,10000,50000,100000,250000,500000],"256":[10,100,1000,5000,10000,50000,100000,250000],"512":[10,100,1000,5000,10000,50000,100000],"1024":[10,100,1000,5000,10000,50000],"4096":[10,100,1000,5000,10000],"16384":[10,100,1000,5000],"65536":[10,100,1000]}
+TF_VAR_test_duration=20
+TF_VAR_num_runs=3
+
+# Infrastructure sizing
+TF_VAR_broker_volume_size=20
+TF_VAR_load_generator_volume_size=8

--- a/scenarios/aws/multiple_run_latency/main.tf
+++ b/scenarios/aws/multiple_run_latency/main.tf
@@ -115,7 +115,7 @@ resource "terraform_data" "multiple_latency_tests" {
     ]
   }
 
-  depends_on = [module.broker.user_ids]
+  depends_on = [module.broker.user_ids, module.load_generator]
 }
 
 # Outputs

--- a/scenarios/aws/multiple_run_throughput/defaults.env
+++ b/scenarios/aws/multiple_run_throughput/defaults.env
@@ -1,0 +1,20 @@
+# Shared non-secret defaults for the multiple_run_throughput scenario.
+# Tracked in git. Override any value in your local .env file.
+# Usage (local): dotenv -f defaults.env -f .env -- terraform apply
+# Usage (CI):    loaded automatically by the benchmark workflow.
+
+# AWS region
+TF_VAR_aws_region="us-east-1"
+TF_VAR_aws_availability_zone="us-east-1a"
+
+# AMI / OS
+TF_VAR_ubuntu_code_name="noble"
+
+# Test configuration
+TF_VAR_message_sizes=[16, 64, 256, 512, 1024, 4096, 16384, 65536]
+TF_VAR_test_duration=60
+TF_VAR_num_runs=3
+
+# Infrastructure sizing
+TF_VAR_broker_volume_size=20
+TF_VAR_load_generator_volume_size=8

--- a/scenarios/aws/multiple_run_throughput/main.tf
+++ b/scenarios/aws/multiple_run_throughput/main.tf
@@ -111,7 +111,7 @@ resource "terraform_data" "multiple_throughput_tests" {
     ]
   }
 
-  depends_on = [module.broker.user_ids]
+  depends_on = [module.broker.user_ids, module.load_generator]
 }
 
 # Outputs

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -407,6 +407,15 @@ def main() -> None:
                 except Exception as e:
                     print(f"  WARNING: failed to parse {f}: {e}")
 
+            for existing_f in sorted(out_latency.glob("*_latency.md")):
+                slug = slug_from_filename(existing_f, "_latency")
+                if slug not in parsed_latency:
+                    print(f"  Including existing: {existing_f.name} -> slug={slug}")
+                    try:
+                        parsed_latency[slug] = parse_latency_file(existing_f)
+                    except Exception as e:
+                        print(f"  WARNING: failed to parse existing {existing_f}: {e}")
+
             if parsed_latency:
                 for pct, label in [("p95", "P95"), ("p99", "P99")]:
                     summary = build_latency_summary(parsed_latency, version, pct, label)
@@ -435,6 +444,15 @@ def main() -> None:
                     parsed_throughput[slug] = parse_throughput_file(f)
                 except Exception as e:
                     print(f"  WARNING: failed to parse {f}: {e}")
+
+            for existing_f in sorted(out_throughput.glob("*_throughput.md")):
+                slug = slug_from_filename(existing_f, "_throughput")
+                if slug not in parsed_throughput:
+                    print(f"  Including existing: {existing_f.name} -> slug={slug}")
+                    try:
+                        parsed_throughput[slug] = parse_throughput_file(existing_f)
+                    except Exception as e:
+                        print(f"  WARNING: failed to parse existing {existing_f}: {e}")
 
             if parsed_throughput:
                 summary = build_throughput_summary(parsed_throughput, version)

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+Aggregate per-instance benchmark result files into summary markdown files.
+
+Usage:
+    python aggregate_results.py \\
+        --version 2.7.0-rc.3 \\
+        --latency-dir  ./raw-results/latency \\
+        --throughput-dir ./raw-results/throughput \\
+        --output-dir results
+"""
+
+import argparse
+import os
+import re
+import shutil
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Instance metadata: slug -> (display_name, description)
+# slug uses dashes, matching the artifact/file naming convention.
+# ---------------------------------------------------------------------------
+INSTANCE_META = {
+    "t4g-micro":  ("t4g.micro",  "2 vCPU, 1 GiB RAM (ARM-based AWS Graviton2)"),
+    "t4g-small":  ("t4g.small",  "2 vCPU, 2 GiB RAM (ARM-based AWS Graviton2)"),
+    "t4g-medium": ("t4g.medium", "2 vCPU, 4 GiB RAM (ARM-based AWS Graviton2)"),
+    "r7g-medium": ("r7g.medium", "1 vCPU, 8 GiB RAM (ARM-based AWS Graviton3)"),
+    "r7g-large":  ("r7g.large",  "2 vCPU, 16 GiB RAM (ARM-based AWS Graviton3)"),
+    "r7g-xlarge": ("r7g.xlarge", "4 vCPU, 32 GiB RAM (ARM-based AWS Graviton3)"),
+    "c8g-large":  ("c8g.large",  "2 vCPU, 4 GiB RAM (ARM-based AWS Graviton4)"),
+    "c7a-large":  ("c7a.large",  "2 vCPU, 4 GiB RAM (AMD-based 4th gen EPYC)"),
+    "i8g-large":  ("i8g.large",  "2 vCPU, 16 GiB RAM (ARM-based AWS Graviton4, local NVMe)"),
+    "i7i-large":  ("i7i.large",  "2 vCPU, 16 GiB RAM (AMD-based Intel Xeon 5th gen, local NVMe)"),
+    "z1d-large":  ("z1d.large",  "2 vCPU, 16 GiB RAM (AMD-based Intel Xeon Scalable)"),
+}
+
+# Display order: group name -> list of slugs
+INSTANCE_GROUPS = [
+    ("Burstable General-Purpose",      ["t4g-micro", "t4g-small", "t4g-medium"]),
+    ("Memory Optimized",               ["r7g-medium", "r7g-large", "r7g-xlarge"]),
+    ("CPU Optimized",                  ["c8g-large", "c7a-large"]),
+    ("Storage Optimized",              ["i8g-large", "i7i-large"]),
+    ("High Single-Threaded Performance", ["z1d-large"]),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def slug_from_filename(path: Path, suffix: str) -> str:
+    """
+    'c8g-large_latency.md' -> 'c8g-large'
+    Handles dots in original matrix.broker names that GitHub Actions may have
+    kept or replaced with dashes.
+    """
+    name = path.stem  # strip .md
+    if name.endswith(suffix):
+        name = name[: -len(suffix)]
+    # normalise dots to dashes
+    return name.replace(".", "-").rstrip("-_")
+
+
+def fmt_num(value: str) -> str:
+    """Format an integer string with thousand separators: '994301' -> '994,301'."""
+    try:
+        return f"{int(value):,}"
+    except (ValueError, TypeError):
+        return str(value)
+
+
+def fmt_float(value: str, decimals: int = 2) -> str:
+    try:
+        return f"{float(value):.{decimals}f}"
+    except (ValueError, TypeError):
+        return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Latency parsing
+# ---------------------------------------------------------------------------
+
+def parse_latency_file(path: Path) -> dict:
+    """
+    Parse a per-instance latency_results.md produced by run_multiple_latency_tests.sh.
+
+    Returns:
+        {
+          "instance_type": str,          # from '# t4g.micro' header
+          "lavinmq_version": str,
+          "duration": str,
+          "sizes": [int, ...],
+          "data": {
+            size_int: {
+              rate_int: {
+                "min": str, "median": str, "p75": str, "p95": str, "p99": str,
+                "pub_rate": str, "pub_bw": str, "con_bw": str
+              }
+            }
+          }
+        }
+    """
+    text = path.read_text()
+    result = {
+        "instance_type": "",
+        "lavinmq_version": "",
+        "duration": "",
+        "sizes": [],
+        "data": {},
+    }
+
+    # Instance type from first heading
+    m = re.search(r"^#\s+(.+)$", text, re.MULTILINE)
+    if m:
+        result["instance_type"] = m.group(1).strip()
+
+    # Duration
+    m = re.search(r"Duration:\s*(\d+)\s*seconds", text)
+    if m:
+        result["duration"] = m.group(1)
+
+    # Find each "## Message Size: N bytes" section
+    # Use the Summary table when present (multi-run), otherwise the single table.
+    size_sections = re.split(r"^## Message Size:\s*(\d+)\s*bytes", text, flags=re.MULTILINE)
+    # size_sections[0] = preamble, then pairs of (size_str, section_text)
+    i = 1
+    while i < len(size_sections) - 1:
+        size = int(size_sections[i])
+        section = size_sections[i + 1]
+        i += 2
+
+        result["sizes"].append(size)
+        result["data"][size] = {}
+
+        # Prefer "### Summary" block when num_runs > 1
+        summary_match = re.search(r"### Summary[^\n]*\n(.*?)(?=^###|\Z)", section,
+                                  re.DOTALL | re.MULTILINE)
+        table_text = summary_match.group(1) if summary_match else section
+
+        # Parse markdown table rows (skip header and separator)
+        for row in re.finditer(
+            r"^\|\s*([\d,]+)\s*\|"   # rate
+            r"\s*([\d.]+)\s*\|"       # min
+            r"\s*([\d.]+)\s*\|"       # median
+            r"\s*([\d.]+)\s*\|"       # p75
+            r"\s*([\d.]+)\s*\|"       # p95
+            r"\s*([\d.]+)\s*\|"       # p99
+            r"\s*([\d,]+)\s*\|"       # pub_rate
+            r"\s*([\d.]+)\s*\|"       # pub_bw
+            r"\s*([\d.]+)\s*\|",      # con_bw
+            table_text,
+            re.MULTILINE,
+        ):
+            rate = int(row.group(1).replace(",", ""))
+            result["data"][size][rate] = {
+                "min":      row.group(2),
+                "median":   row.group(3),
+                "p75":      row.group(4),
+                "p95":      row.group(5),
+                "p99":      row.group(6),
+                "pub_rate": row.group(7).replace(",", ""),
+                "pub_bw":   row.group(8),
+                "con_bw":   row.group(9),
+            }
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Throughput parsing
+# ---------------------------------------------------------------------------
+
+def parse_throughput_file(path: Path) -> dict:
+    """
+    Parse a per-instance throughput_results.md produced by run_multiple_throughput_tests.sh.
+
+    Returns:
+        {
+          "instance_type": str,
+          "lavinmq_version": str,
+          "duration": str,
+          "data": {
+            size_int: {
+              "pub_rate": str, "con_rate": str, "pub_bw": str, "con_bw": str
+            }
+          }
+        }
+    """
+    text = path.read_text()
+    result = {
+        "instance_type": "",
+        "lavinmq_version": "",
+        "duration": "",
+        "data": {},
+    }
+
+    m = re.search(r"Broker Instance Type:\s*(.+)$", text, re.MULTILINE)
+    if m:
+        result["instance_type"] = m.group(1).strip()
+
+    m = re.search(r"LavinMQ Version:\s*(.+)$", text, re.MULTILINE)
+    if m:
+        result["lavinmq_version"] = m.group(1).strip()
+
+    m = re.search(r"Duration:\s*(\d+)\s*seconds", text)
+    if m:
+        result["duration"] = m.group(1)
+
+    # Prefer "### Summary" table when present
+    summary_match = re.search(r"### Summary[^\n]*\n(.*?)(?=^###|^##|\Z)", text,
+                               re.DOTALL | re.MULTILINE)
+    table_text = summary_match.group(1) if summary_match else text
+
+    for row in re.finditer(
+        r"^\|\s*(\d+)\s*\|"          # size
+        r"\s*([\d,]+)\s*\|"          # pub_rate
+        r"\s*([\d,]+)\s*\|"          # con_rate
+        r"\s*([\d.]+)\s*\|"          # pub_bw
+        r"\s*([\d.]+)\s*\|",         # con_bw
+        table_text,
+        re.MULTILINE,
+    ):
+        size = int(row.group(1))
+        result["data"][size] = {
+            "pub_rate": row.group(2).replace(",", ""),
+            "con_rate": row.group(3).replace(",", ""),
+            "pub_bw":   row.group(4),
+            "con_bw":   row.group(5),
+        }
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Latency summary builders
+# ---------------------------------------------------------------------------
+
+def build_latency_summary(
+    parsed: dict,           # slug -> parse_latency_file result
+    version: str,
+    percentile: str,        # "p95" or "p99"
+    col_label: str,         # "P95" or "P99"
+) -> str:
+    # Collect all sizes and rates seen across all instances
+    all_sizes: list[int] = sorted({
+        s for p in parsed.values() for s in p["data"]
+    })
+    all_rates: list[int] = sorted({
+        r for p in parsed.values() for s in p["data"].values() for r in s
+    })
+
+    lines = []
+    lines.append(f"# LavinMQ {col_label} Latency Results\n")
+    lines.append(
+        f"***Important***: These results are from {next(iter(parsed.values()))['duration']}s "
+        "test runs per instance type. Anomalies may be due to transient network conditions, "
+        "CPU throttling/bursting, background system processes, or queue state variations.\n"
+    )
+    lines.append("## Benchmark Setup\n")
+    lines.append(
+        "- Network (VPC, internet gateway, subnet, route table, route table associated, ingress rule)\n"
+        "- Benchmark-broker (AWS instance, public IP)\n"
+        "- Benchmark-loadgen (AWS instance, public IP)\n"
+        "\nLoad generator -> AMQP-URL (broker private IP) -> Broker\n"
+    )
+    lines.append("## Table Headers\n")
+    lines.append(
+        "- **Rate limit**: Rate limit in msgs/s\n"
+        f"- **Message Sizes**: {', '.join(str(s) for s in all_sizes)} bytes\n"
+    )
+    lines.append("## AWS Instance Types\n")
+    lines.append(
+        f"Benchmark results for AWS instance types with LavinMQ version v{version}.\n"
+    )
+
+    duration = next(iter(parsed.values()), {}).get("duration", "20")
+    lines.append("```shell")
+    lines.append(f"lavinmqperf throughput -z {duration} -x 1 -y 1 -s <size> -r <rate-limit> --measure-latency")
+    lines.append("```\n")
+
+    size_headers = " | ".join(f"{s} bytes" for s in all_sizes)
+    size_sep = " | ".join("---------:" for _ in all_sizes)
+    header_row = f"| Rate Limit | {size_headers} |"
+    sep_row    = f"|-----------:| {size_sep} |"
+
+    for group_name, slugs in INSTANCE_GROUPS:
+        group_instances = [(s, parsed[s]) for s in slugs if s in parsed]
+        if not group_instances:
+            continue
+        lines.append(f"### {group_name}\n")
+        for slug, p in group_instances:
+            display, desc = INSTANCE_META.get(slug, (slug, ""))
+            lines.append(f"**{display}** - {desc}\n")
+            lines.append(header_row)
+            lines.append(sep_row)
+            for rate in all_rates:
+                cells = []
+                for size in all_sizes:
+                    val = p["data"].get(size, {}).get(rate, {}).get(percentile, "")
+                    cells.append(f"{fmt_float(val):>9}" if val else "        -")
+                rate_fmt = fmt_num(str(rate))
+                lines.append(f"| {rate_fmt:>10} | {' | '.join(cells)} |")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Throughput summary builder
+# ---------------------------------------------------------------------------
+
+def build_throughput_summary(parsed: dict, version: str) -> str:
+    all_sizes: list[int] = sorted({
+        s for p in parsed.values() for s in p["data"]
+    })
+
+    lines = []
+    lines.append("# LavinMQ Throughput Results\n")
+    lines.append("## Benchmark Setup\n")
+    lines.append(
+        "- Network (VPC, internet gateway, subnet, route table, route table associated, ingress rule)\n"
+        "- Benchmark-broker (AWS instance, public IP)\n"
+        "- Benchmark-loadgen (AWS instance, public IP)\n"
+        "\nLoad generator -> AMQP-URL (broker private IP) -> Broker\n"
+    )
+    lines.append("## Table Headers\n")
+    lines.append(
+        "- **Size**: Message size in bytes\n"
+        "- **Avg. Publish Rate**: Average publish rate in msgs/s\n"
+        "- **Avg. Consume Rate**: Average consume rate in msgs/s\n"
+        "- **Publish BW**: Publish bandwidth in MiB/s\n"
+        "- **Consume BW**: Consume bandwidth in MiB/s\n"
+    )
+    lines.append("## AWS Instance Types\n")
+    duration = next(iter(parsed.values()), {}).get("duration", "60")
+    lines.append(f"Benchmark results for AWS instance types with LavinMQ version v{version}.\n")
+    lines.append("```shell")
+    lines.append(f"lavinmqperf throughput -z {duration} -x 1 -y 1 -s <size>")
+    lines.append("```\n")
+
+    header_row = "| {:>5} | {:>17} | {:>17} | {:>11} | {:>11} |".format(
+        "Size", "Avg. Publish Rate", "Avg. Consume Rate", "Publish BW", "Consume BW"
+    )
+    sep_row = "|------:|------------------:|------------------:|------------:|------------:|"
+
+    for group_name, slugs in INSTANCE_GROUPS:
+        group_instances = [(s, parsed[s]) for s in slugs if s in parsed]
+        if not group_instances:
+            continue
+        lines.append(f"### {group_name}\n")
+        for slug, p in group_instances:
+            display, desc = INSTANCE_META.get(slug, (slug, ""))
+            lines.append(f"**{display}** - {desc}\n")
+            lines.append(header_row)
+            lines.append(sep_row)
+            for size in all_sizes:
+                row = p["data"].get(size)
+                if not row:
+                    continue
+                lines.append(
+                    "| {:>5} | {:>17} | {:>17} | {:>11} | {:>11} |".format(
+                        size,
+                        fmt_num(row["pub_rate"]),
+                        fmt_num(row["con_rate"]),
+                        fmt_float(row["pub_bw"]),
+                        fmt_float(row["con_bw"]),
+                    )
+                )
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Aggregate LavinMQ benchmark results.")
+    parser.add_argument("--version",        required=True,  help="LavinMQ version, e.g. 2.7.0-rc.3")
+    parser.add_argument("--latency-dir",    default=None,   help="Directory containing per-instance *_latency.md files")
+    parser.add_argument("--throughput-dir", default=None,   help="Directory containing per-instance *_throughput.md files")
+    parser.add_argument("--output-dir",     required=True,  help="Root results directory (e.g. results/)")
+    args = parser.parse_args()
+
+    version = args.version.lstrip("v")
+    out_root = Path(args.output_dir) / f"v{version}"
+
+    # ---- Latency -----------------------------------------------------------
+    if args.latency_dir:
+        latency_dir = Path(args.latency_dir)
+        latency_files = sorted(latency_dir.glob("**/*_latency.md"))
+        if latency_files:
+            out_latency = out_root / "latency"
+            out_latency.mkdir(parents=True, exist_ok=True)
+
+            parsed_latency: dict = {}
+            for f in latency_files:
+                slug = slug_from_filename(f, "_latency")
+                print(f"  Parsing latency: {f.name} -> slug={slug}")
+                # Copy raw file
+                dest = out_latency / f"{slug}_latency.md"
+                shutil.copy2(f, dest)
+                # Parse
+                try:
+                    parsed_latency[slug] = parse_latency_file(f)
+                except Exception as e:
+                    print(f"  WARNING: failed to parse {f}: {e}")
+
+            if parsed_latency:
+                for pct, label in [("p95", "P95"), ("p99", "P99")]:
+                    summary = build_latency_summary(parsed_latency, version, pct, label)
+                    out_path = out_root / f"latency_{label}.md"
+                    out_path.write_text(summary)
+                    print(f"  Written: {out_path}")
+        else:
+            print(f"  No latency files found in {latency_dir}")
+
+    # ---- Throughput --------------------------------------------------------
+    if args.throughput_dir:
+        throughput_dir = Path(args.throughput_dir)
+        throughput_files = sorted(throughput_dir.glob("**/*_throughput.md"))
+        if throughput_files:
+            out_throughput = out_root / "throughput"
+            out_throughput.mkdir(parents=True, exist_ok=True)
+
+            parsed_throughput: dict = {}
+            for f in throughput_files:
+                slug = slug_from_filename(f, "_throughput")
+                print(f"  Parsing throughput: {f.name} -> slug={slug}")
+                dest = out_throughput / f"{slug}_throughput.md"
+                shutil.copy2(f, dest)
+                try:
+                    parsed_throughput[slug] = parse_throughput_file(f)
+                except Exception as e:
+                    print(f"  WARNING: failed to parse {f}: {e}")
+
+            if parsed_throughput:
+                summary = build_throughput_summary(parsed_throughput, version)
+                out_path = out_root / "throughput.md"
+                out_path.write_text(summary)
+                print(f"  Written: {out_path}")
+        else:
+            print(f"  No throughput files found in {throughput_dir}")
+
+    print("Aggregation complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -387,7 +387,7 @@ def main() -> None:
     out_root = Path(args.output_dir) / f"v{version}"
 
     # ---- Latency -----------------------------------------------------------
-    if args.latency_dir:
+    if args.latency_dir and Path(args.latency_dir).is_dir():
         latency_dir = Path(args.latency_dir)
         latency_files = sorted(latency_dir.glob("**/*_latency.md"))
         if latency_files:
@@ -413,11 +413,12 @@ def main() -> None:
                     out_path = out_root / f"latency_{label}.md"
                     out_path.write_text(summary)
                     print(f"  Written: {out_path}")
+
         else:
             print(f"  No latency files found in {latency_dir}")
 
     # ---- Throughput --------------------------------------------------------
-    if args.throughput_dir:
+    if args.throughput_dir and Path(args.throughput_dir).is_dir():
         throughput_dir = Path(args.throughput_dir)
         throughput_files = sorted(throughput_dir.glob("**/*_throughput.md"))
         if throughput_files:


### PR DESCRIPTION
### WHY are these changes introduced?

First step toward fully automated benchmarking. Previously, benchmark runs had to be triggered and managed manually. This lays the groundwork for running all instance types in parallel and eventually triggering runs automatically on new LavinMQ releases.

### WHAT is this pull request doing?

- Adds a GitHub Actions workflow (`benchmark.yml`) that provisions AWS infrastructure via Terraform
- Runs latency and throughput benchmarks across all supported instance types in parallel
- Aggregates the results into markdown summary files, and opens a PR with the results.

Scenarios (all / latency / throughput) and the LavinMQ version are selectable at trigger time.
Prepared to be able to add more scenarios later on, e.g. MQTT benchmarks.

### HOW was this pull request tested?

Manual trigger

```console
gh workflow run benchmark.yml \
  -r "CI/trigger-runs" \
  -f lavinmq_version=2.7.0 \
  -f scenarios=<all/latency/throughput>
```

Created pull request: #42