### PR TITLE
Remove Elastic IP address resource

### DIFF
--- a/modules/providers/aws/instance/instance.tf
+++ b/modules/providers/aws/instance/instance.tf
@@ -23,22 +23,10 @@ resource "aws_instance" "instance" {
   }
 }
 
-resource "aws_eip" "this" {
-  domain = "vpc"
-
-  instance                  = aws_instance.instance.id
-  associate_with_private_ip = aws_instance.instance.private_ip
-
-  tags = {
-    Name      = var.tag_name
-    CreatedBy = var.tag_created_by
-  }
-}
-
 output "public_dns" {
-  value = aws_eip.this.public_dns
+  value = aws_instance.instance.public_dns
 }
 
 output "private_ip" {
-  value = aws_eip.this.private_ip
+  value = aws_instance.instance.private_ip
 }


### PR DESCRIPTION
No need to use Elastic IP address since the instance already have an assigned public IP. This also avoid AWS quotas limits for EIP per region.