### PR TITLE
Replace markdown result files with CSV + JSON output

### DIFF
--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -169,15 +169,20 @@ jobs:
           LG=$(terraform output -state="${{ env.state_file }}" -raw load_generator_public_dns)
           scp -o StrictHostKeyChecking=accept-new \
               -o UserKnownHostsFile=/tmp/known-hosts-latency-${{ env.broker_safe }} \
-              ubuntu@${LG}:/home/ubuntu/latency_results.md \
-              "${{ github.workspace }}/${{ env.broker_safe }}_latency.md"
+              ubuntu@${LG}:/home/ubuntu/latency_results.csv \
+              ubuntu@${LG}:/home/ubuntu/latency_results.json \
+              "${{ github.workspace }}/"
+          mv "${{ github.workspace }}/latency_results.csv" "${{ github.workspace }}/${{ env.broker_safe }}_latency.csv"
+          mv "${{ github.workspace }}/latency_results.json" "${{ github.workspace }}/${{ env.broker_safe }}_latency.json"
 
       - name: Upload artifact
         if: steps.apply.outcome == 'success' && steps.download.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: latency-${{ matrix.broker }}
-          path: ${{ env.broker_safe }}_latency.md
+          path: |
+            ${{ env.broker_safe }}_latency.csv
+            ${{ env.broker_safe }}_latency.json
           if-no-files-found: error
 
       - name: Terraform destroy

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -159,15 +159,20 @@ jobs:
           LG=$(terraform output -state="${{ env.state_file }}" -raw load_generator_public_dns)
           scp -o StrictHostKeyChecking=accept-new \
               -o UserKnownHostsFile=/tmp/known-hosts-throughput-${{ env.broker_safe }} \
-              ubuntu@${LG}:/home/ubuntu/throughput_results.md \
-              "${{ github.workspace }}/${{ env.broker_safe }}_throughput.md"
+              ubuntu@${LG}:/home/ubuntu/throughput_results.csv \
+              ubuntu@${LG}:/home/ubuntu/throughput_results.json \
+              "${{ github.workspace }}/"
+          mv "${{ github.workspace }}/throughput_results.csv" "${{ github.workspace }}/${{ env.broker_safe }}_throughput.csv"
+          mv "${{ github.workspace }}/throughput_results.json" "${{ github.workspace }}/${{ env.broker_safe }}_throughput.json"
 
       - name: Upload artifact
         if: steps.apply.outcome == 'success' && steps.download.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: throughput-${{ matrix.broker }}
-          path: ${{ env.broker_safe }}_throughput.md
+          path: |
+            ${{ env.broker_safe }}_throughput.csv
+            ${{ env.broker_safe }}_throughput.json
           if-no-files-found: error
 
       - name: Terraform destroy

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Check that at least one artifact was downloaded
         run: |
-          if [ -z "$(find raw-results -name '*.md' 2>/dev/null)" ]; then
+          if [ -z "$(find raw-results -name '*.csv' 2>/dev/null)" ]; then
             echo "No result files found – all benchmark jobs failed. Skipping PR."
             echo "has_results=false" >> "$GITHUB_ENV"
           else

--- a/scenarios/aws/multiple_run_latency/main.tf
+++ b/scenarios/aws/multiple_run_latency/main.tf
@@ -130,16 +130,21 @@ output "load_generator_public_dns" {
 }
 
 output "results_file_path" {
-  description = "Path to the results file on the load generator instance"
-  value       = "/home/ubuntu/latency_results.md"
+  description = "Path to the results CSV file on the load generator instance"
+  value       = "/home/ubuntu/latency_results.csv"
+}
+
+output "results_config_path" {
+  description = "Path to the results JSON config file on the load generator instance"
+  value       = "/home/ubuntu/latency_results.json"
 }
 
 output "ssh_view_results_command" {
   description = "Command to SSH and view the results"
-  value       = format("ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known-hosts ubuntu@%s 'cat /home/ubuntu/latency_results.md'", module.load_generator.public_dns)
+  value       = format("ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known-hosts ubuntu@%s 'cat /home/ubuntu/latency_results.csv'", module.load_generator.public_dns)
 }
 
 output "scp_download_results_command" {
-  description = "Command to download the results file using SCP"
-  value       = format("scp -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known-hosts ubuntu@%s:/home/ubuntu/latency_results.md ./latency_results.md", module.load_generator.public_dns)
+  description = "Commands to download the results files using SCP"
+  value       = format("scp -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known-hosts ubuntu@%s:'/home/ubuntu/latency_results.csv /home/ubuntu/latency_results.json' .", module.load_generator.public_dns)
 }

--- a/scenarios/aws/multiple_run_throughput/main.tf
+++ b/scenarios/aws/multiple_run_throughput/main.tf
@@ -126,16 +126,21 @@ output "load_generator_public_dns" {
 }
 
 output "results_file_path" {
-  description = "Path to the results file on the load generator instance"
-  value       = "/home/ubuntu/throughput_results.md"
+  description = "Path to the results CSV file on the load generator instance"
+  value       = "/home/ubuntu/throughput_results.csv"
+}
+
+output "results_config_path" {
+  description = "Path to the results JSON config file on the load generator instance"
+  value       = "/home/ubuntu/throughput_results.json"
 }
 
 output "ssh_view_results_command" {
   description = "Command to SSH and view the results"
-  value       = format("ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known-hosts ubuntu@%s 'cat /home/ubuntu/throughput_results.md'", module.load_generator.public_dns)
+  value       = format("ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known-hosts ubuntu@%s 'cat /home/ubuntu/throughput_results.csv'", module.load_generator.public_dns)
 }
 
 output "scp_download_results_command" {
-  description = "Command to download the results file using SCP"
-  value       = format("scp -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known-hosts ubuntu@%s:/home/ubuntu/throughput_results.md ./throughput_results.md", module.load_generator.public_dns)
+  description = "Commands to download the results files using SCP"
+  value       = format("scp -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/tmp/known-hosts ubuntu@%s:'/home/ubuntu/throughput_results.csv /home/ubuntu/throughput_results.json' .", module.load_generator.public_dns)
 }

--- a/scripts/aggregate_results.py
+++ b/scripts/aggregate_results.py
@@ -11,9 +11,12 @@ Usage:
 """
 
 import argparse
+import csv
+import json
 import os
 import re
 import shutil
+import statistics
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -80,13 +83,14 @@ def fmt_float(value: str, decimals: int = 2) -> str:
 # Latency parsing
 # ---------------------------------------------------------------------------
 
-def parse_latency_file(path: Path) -> dict:
+def parse_latency_files(csv_path: Path, json_path: Path) -> dict:
     """
-    Parse a per-instance latency_results.md produced by run_multiple_latency_tests.sh.
+    Parse per-instance latency results from CSV + JSON config files produced
+    by run_multiple_latency_tests.sh.
 
-    Returns:
+    Returns the same dict shape as the former parse_latency_file():
         {
-          "instance_type": str,          # from '# t4g.micro' header
+          "instance_type": str,
           "lavinmq_version": str,
           "duration": str,
           "sizes": [int, ...],
@@ -100,68 +104,35 @@ def parse_latency_file(path: Path) -> dict:
           }
         }
     """
-    text = path.read_text()
-    result = {
-        "instance_type": "",
-        "lavinmq_version": "",
-        "duration": "",
-        "sizes": [],
-        "data": {},
+    with json_path.open() as f:
+        cfg = json.load(f)
+
+    result: dict = {
+        "instance_type":   cfg.get("instance_type", ""),
+        "lavinmq_version": cfg.get("lavinmq_version", ""),
+        "duration":        str(cfg.get("duration", "")),
+        "sizes":           [int(s) for s in cfg.get("sizes", [])],
+        "data":            {},
     }
 
-    # Instance type from first heading
-    m = re.search(r"^#\s+(.+)$", text, re.MULTILINE)
-    if m:
-        result["instance_type"] = m.group(1).strip()
+    # Group rows by (size, rate_limit)
+    groups: dict = {}
+    with csv_path.open(newline="") as f:
+        for row in csv.DictReader(f):
+            key = (int(row["Size"]), int(row["RateLimit"]))
+            groups.setdefault(key, []).append(row)
 
-    # Duration
-    m = re.search(r"Duration:\s*(\d+)\s*seconds", text)
-    if m:
-        result["duration"] = m.group(1)
-
-    # Find each "## Message Size: N bytes" section
-    # Use the Summary table when present (multi-run), otherwise the single table.
-    size_sections = re.split(r"^## Message Size:\s*(\d+)\s*bytes", text, flags=re.MULTILINE)
-    # size_sections[0] = preamble, then pairs of (size_str, section_text)
-    i = 1
-    while i < len(size_sections) - 1:
-        size = int(size_sections[i])
-        section = size_sections[i + 1]
-        i += 2
-
-        result["sizes"].append(size)
-        result["data"][size] = {}
-
-        # Prefer "### Summary" block when num_runs > 1
-        summary_match = re.search(r"### Summary[^\n]*\n(.*?)(?=^###|\Z)", section,
-                                  re.DOTALL | re.MULTILINE)
-        table_text = summary_match.group(1) if summary_match else section
-
-        # Parse markdown table rows (skip header and separator)
-        for row in re.finditer(
-            r"^\|\s*([\d,]+)\s*\|"   # rate
-            r"\s*([\d.]+)\s*\|"       # min
-            r"\s*([\d.]+)\s*\|"       # median
-            r"\s*([\d.]+)\s*\|"       # p75
-            r"\s*([\d.]+)\s*\|"       # p95
-            r"\s*([\d.]+)\s*\|"       # p99
-            r"\s*([\d,]+)\s*\|"       # pub_rate
-            r"\s*([\d.]+)\s*\|"       # pub_bw
-            r"\s*([\d.]+)\s*\|",      # con_bw
-            table_text,
-            re.MULTILINE,
-        ):
-            rate = int(row.group(1).replace(",", ""))
-            result["data"][size][rate] = {
-                "min":      row.group(2),
-                "median":   row.group(3),
-                "p75":      row.group(4),
-                "p95":      row.group(5),
-                "p99":      row.group(6),
-                "pub_rate": row.group(7).replace(",", ""),
-                "pub_bw":   row.group(8),
-                "con_bw":   row.group(9),
-            }
+    for (size, rate), rows in groups.items():
+        result["data"].setdefault(size, {})[rate] = {
+            "min":      f"{statistics.median(float(r['Min'])      for r in rows):.2f}",
+            "median":   f"{statistics.median(float(r['Median'])   for r in rows):.2f}",
+            "p75":      f"{statistics.median(float(r['P75'])      for r in rows):.2f}",
+            "p95":      f"{statistics.median(float(r['P95'])      for r in rows):.2f}",
+            "p99":      f"{statistics.median(float(r['P99'])      for r in rows):.2f}",
+            "pub_rate": str(round(statistics.median(float(r['PubRate']) for r in rows))),
+            "pub_bw":   f"{statistics.median(float(r['PubBW'])    for r in rows):.2f}",
+            "con_bw":   f"{statistics.median(float(r['ConBW'])    for r in rows):.2f}",
+        }
 
     return result
 
@@ -170,11 +141,12 @@ def parse_latency_file(path: Path) -> dict:
 # Throughput parsing
 # ---------------------------------------------------------------------------
 
-def parse_throughput_file(path: Path) -> dict:
+def parse_throughput_files(csv_path: Path, json_path: Path) -> dict:
     """
-    Parse a per-instance throughput_results.md produced by run_multiple_throughput_tests.sh.
+    Parse per-instance throughput results from CSV + JSON config files produced
+    by run_multiple_throughput_tests.sh.
 
-    Returns:
+    Returns the same dict shape as the former parse_throughput_file():
         {
           "instance_type": str,
           "lavinmq_version": str,
@@ -186,46 +158,28 @@ def parse_throughput_file(path: Path) -> dict:
           }
         }
     """
-    text = path.read_text()
-    result = {
-        "instance_type": "",
-        "lavinmq_version": "",
-        "duration": "",
-        "data": {},
+    with json_path.open() as f:
+        cfg = json.load(f)
+
+    result: dict = {
+        "instance_type":   cfg.get("instance_type", ""),
+        "lavinmq_version": cfg.get("lavinmq_version", ""),
+        "duration":        str(cfg.get("duration", "")),
+        "data":            {},
     }
 
-    m = re.search(r"Broker Instance Type:\s*(.+)$", text, re.MULTILINE)
-    if m:
-        result["instance_type"] = m.group(1).strip()
+    groups: dict = {}
+    with csv_path.open(newline="") as f:
+        for row in csv.DictReader(f):
+            key = int(row["Size"])
+            groups.setdefault(key, []).append(row)
 
-    m = re.search(r"LavinMQ Version:\s*(.+)$", text, re.MULTILINE)
-    if m:
-        result["lavinmq_version"] = m.group(1).strip()
-
-    m = re.search(r"Duration:\s*(\d+)\s*seconds", text)
-    if m:
-        result["duration"] = m.group(1)
-
-    # Prefer "### Summary" table when present
-    summary_match = re.search(r"### Summary[^\n]*\n(.*?)(?=^###|^##|\Z)", text,
-                               re.DOTALL | re.MULTILINE)
-    table_text = summary_match.group(1) if summary_match else text
-
-    for row in re.finditer(
-        r"^\|\s*(\d+)\s*\|"          # size
-        r"\s*([\d,]+)\s*\|"          # pub_rate
-        r"\s*([\d,]+)\s*\|"          # con_rate
-        r"\s*([\d.]+)\s*\|"          # pub_bw
-        r"\s*([\d.]+)\s*\|",         # con_bw
-        table_text,
-        re.MULTILINE,
-    ):
-        size = int(row.group(1))
+    for size, rows in groups.items():
         result["data"][size] = {
-            "pub_rate": row.group(2).replace(",", ""),
-            "con_rate": row.group(3).replace(",", ""),
-            "pub_bw":   row.group(4),
-            "con_bw":   row.group(5),
+            "pub_rate": str(round(statistics.median(float(r['PubRate']) for r in rows))),
+            "con_rate": str(round(statistics.median(float(r['ConRate']) for r in rows))),
+            "pub_bw":   f"{statistics.median(float(r['PubBW']) for r in rows):.2f}",
+            "con_bw":   f"{statistics.median(float(r['ConBW']) for r in rows):.2f}",
         }
 
     return result
@@ -378,8 +332,8 @@ def build_throughput_summary(parsed: dict, version: str) -> str:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Aggregate LavinMQ benchmark results.")
     parser.add_argument("--version",        required=True,  help="LavinMQ version, e.g. 2.7.0-rc.3")
-    parser.add_argument("--latency-dir",    default=None,   help="Directory containing per-instance *_latency.md files")
-    parser.add_argument("--throughput-dir", default=None,   help="Directory containing per-instance *_throughput.md files")
+    parser.add_argument("--latency-dir",    default=None,   help="Directory containing per-instance *_latency.csv files (with matching *_latency.json)")
+    parser.add_argument("--throughput-dir", default=None,   help="Directory containing per-instance *_throughput.csv files (with matching *_throughput.json)")
     parser.add_argument("--output-dir",     required=True,  help="Root results directory (e.g. results/)")
     args = parser.parse_args()
 
@@ -389,7 +343,7 @@ def main() -> None:
     # ---- Latency -----------------------------------------------------------
     if args.latency_dir and Path(args.latency_dir).is_dir():
         latency_dir = Path(args.latency_dir)
-        latency_files = sorted(latency_dir.glob("**/*_latency.md"))
+        latency_files = sorted(latency_dir.glob("**/*_latency.csv"))
         if latency_files:
             out_latency = out_root / "latency"
             out_latency.mkdir(parents=True, exist_ok=True)
@@ -398,21 +352,23 @@ def main() -> None:
             for f in latency_files:
                 slug = slug_from_filename(f, "_latency")
                 print(f"  Parsing latency: {f.name} -> slug={slug}")
-                # Copy raw file
-                dest = out_latency / f"{slug}_latency.md"
-                shutil.copy2(f, dest)
+                # Copy raw files
+                shutil.copy2(f, out_latency / f"{slug}_latency.csv")
+                json_src = f.with_suffix(".json")
+                if json_src.exists():
+                    shutil.copy2(json_src, out_latency / f"{slug}_latency.json")
                 # Parse
                 try:
-                    parsed_latency[slug] = parse_latency_file(f)
+                    parsed_latency[slug] = parse_latency_files(f, json_src)
                 except Exception as e:
                     print(f"  WARNING: failed to parse {f}: {e}")
 
-            for existing_f in sorted(out_latency.glob("*_latency.md")):
+            for existing_f in sorted(out_latency.glob("*_latency.csv")):
                 slug = slug_from_filename(existing_f, "_latency")
                 if slug not in parsed_latency:
                     print(f"  Including existing: {existing_f.name} -> slug={slug}")
                     try:
-                        parsed_latency[slug] = parse_latency_file(existing_f)
+                        parsed_latency[slug] = parse_latency_files(existing_f, existing_f.with_suffix(".json"))
                     except Exception as e:
                         print(f"  WARNING: failed to parse existing {existing_f}: {e}")
 
@@ -429,7 +385,7 @@ def main() -> None:
     # ---- Throughput --------------------------------------------------------
     if args.throughput_dir and Path(args.throughput_dir).is_dir():
         throughput_dir = Path(args.throughput_dir)
-        throughput_files = sorted(throughput_dir.glob("**/*_throughput.md"))
+        throughput_files = sorted(throughput_dir.glob("**/*_throughput.csv"))
         if throughput_files:
             out_throughput = out_root / "throughput"
             out_throughput.mkdir(parents=True, exist_ok=True)
@@ -438,19 +394,21 @@ def main() -> None:
             for f in throughput_files:
                 slug = slug_from_filename(f, "_throughput")
                 print(f"  Parsing throughput: {f.name} -> slug={slug}")
-                dest = out_throughput / f"{slug}_throughput.md"
-                shutil.copy2(f, dest)
+                shutil.copy2(f, out_throughput / f"{slug}_throughput.csv")
+                json_src = f.with_suffix(".json")
+                if json_src.exists():
+                    shutil.copy2(json_src, out_throughput / f"{slug}_throughput.json")
                 try:
-                    parsed_throughput[slug] = parse_throughput_file(f)
+                    parsed_throughput[slug] = parse_throughput_files(f, json_src)
                 except Exception as e:
                     print(f"  WARNING: failed to parse {f}: {e}")
 
-            for existing_f in sorted(out_throughput.glob("*_throughput.md")):
+            for existing_f in sorted(out_throughput.glob("*_throughput.csv")):
                 slug = slug_from_filename(existing_f, "_throughput")
                 if slug not in parsed_throughput:
                     print(f"  Including existing: {existing_f.name} -> slug={slug}")
                     try:
-                        parsed_throughput[slug] = parse_throughput_file(existing_f)
+                        parsed_throughput[slug] = parse_throughput_files(existing_f, existing_f.with_suffix(".json"))
                     except Exception as e:
                         print(f"  WARNING: failed to parse existing {existing_f}: {e}")
 

--- a/scripts/run_multiple_latency_tests.sh
+++ b/scripts/run_multiple_latency_tests.sh
@@ -21,7 +21,8 @@ DURATION="${4:-120}"  # Default duration 120 seconds if not provided
 BROKER_INSTANCE_TYPE="${5:-unknown}"  # Broker instance type for reporting
 NUM_RUNS="${6:-${BENCHMARK_NUM_RUNS:-1}}"  # Number of runs per combination, default 1
 PER_SIZE_RATE_LIMITS="${7:-}"              # Optional per-size rate limits, format: "size1:r1,r2|size2:r1,r2"
-OUTPUT_FILE="/home/ubuntu/latency_results.md"
+OUTPUT_CSV="/home/ubuntu/latency_results.csv"
+OUTPUT_JSON="/home/ubuntu/latency_results.json"
 TEMP_DIR="/tmp/latency_test_$$"
 QUEUE_NAME="perf-test"
 
@@ -59,7 +60,8 @@ echo "Rate Limits: $RATE_LIMITS msgs/s"
 echo "Per-Size Rate Limits: ${PER_SIZE_RATE_LIMITS:-(using global rate limits)}"
 echo "Test Duration: $DURATION seconds"
 echo "Number of Runs: $NUM_RUNS"
-echo "Output File: $OUTPUT_FILE"
+echo "Output CSV:  $OUTPUT_CSV"
+echo "Output JSON: $OUTPUT_JSON"
 echo "=========================================="
 echo ""
 
@@ -185,115 +187,59 @@ echo "All tests completed!"
 echo "=========================================="
 echo ""
 
-# Generate markdown report
-echo "Generating markdown summary..."
+# Merge per-size CSVs into single output CSV
+echo "Generating CSV output..."
 
-{
-  echo "# $BROKER_INSTANCE_TYPE"
-  echo ""
-  echo "## Test Configuration"
-  echo ""
-  echo "- Duration: $DURATION seconds (\`-z $DURATION\`)"
-  echo "- Producers: 1 (\`-x 1\`)"
-  echo "- Consumers: 1 (\`-y 1\`)"
-  echo "- Runs per combination: $NUM_RUNS"
-  echo "- Message sizes: $SIZES bytes"
-  echo "- Rate limits: $RATE_LIMITS msgs/s"
-  if [ -n "$PER_SIZE_RATE_LIMITS" ]; then
-    echo "- Per-size rate limits override:"
-    IFS='|' read -ra _PAIRS <<< "$PER_SIZE_RATE_LIMITS"
-    for _PAIR in "${_PAIRS[@]}"; do
-      echo "  - ${_PAIR%%:*} bytes: ${_PAIR#*:} msgs/s"
-    done
-  fi
-  echo "- Queue: $QUEUE_NAME"
-  echo "- Latency measurement: Enabled (\`--measure-latency\`)"
-  echo ""
-  echo "## Units"
-  echo ""
-  echo "- Rate limits: (msgs/s)"
-  echo "- Latency [min, median, P75, P95, P99]: (ms)"
-  echo "- Publish rate: (msgs/s)"
-  echo "- Publish/consume bandwidth: (MiB/s)"
-  echo ""
+echo "Run,Size,RateLimit,Min,Median,P75,P95,P99,PubRate,PubBW,ConBW" > "$OUTPUT_CSV"
+for SIZE in "${SIZE_ARRAY[@]}"; do
+  SIZE_CSV="$TEMP_DIR/size_${SIZE}.csv"
+  # Insert Size column (position 2) into each data row: Run,RateLimit,... -> Run,Size,RateLimit,...
+  tail -n +2 "$SIZE_CSV" | awk -v size="$SIZE" -F',' 'BEGIN{OFS=","} {print $1,size,$2,$3,$4,$5,$6,$7,$8,$9,$10}' >> "$OUTPUT_CSV"
+done
 
-  # Generate a table for each message size
-  for SIZE in "${SIZE_ARRAY[@]}"; do
-    SIZE_CSV="$TEMP_DIR/size_${SIZE}.csv"
+echo "Results saved to: $OUTPUT_CSV"
 
-    echo "## Message Size: $SIZE bytes"
-    echo ""
+# Write JSON config
+echo "Writing JSON config..."
 
-    if [ "$NUM_RUNS" -eq 1 ]; then
-      echo "| Rate Limit |     Min |  Median |     P75 |     P95 |      P99 | Pub. Rate |  Pub. BW |  Con. BW |"
-      echo "|-----------:|--------:|--------:|--------:|--------:|---------:|----------:|---------:|---------:|"
+# Build JSON arrays from comma-separated strings
+SIZES_JSON=$(printf '%s' "$SIZES" | tr ',' '\n' | awk 'BEGIN{printf "["} NR>1{printf ","} {printf "%s",$1} END{printf "]"}')
+RATE_LIMITS_JSON=$(printf '%s' "$RATE_LIMITS" | tr ',' '\n' | awk 'BEGIN{printf "["} NR>1{printf ","} {printf "%s",$1} END{printf "]"}')
 
-      # Read CSV and format as markdown table (skip header row, skip Run column)
-      tail -n +2 "$SIZE_CSV" | while IFS=',' read -r run rate min_lat median_lat p75_lat p95_lat p99_lat pub_rate pub_bw con_bw; do
-        formatted_rate=$(format_number "$rate")
-        formatted_pub_rate=$(format_number "$pub_rate")
-        [[ "$pub_bw" =~ ^\. ]] && pub_bw="0$pub_bw"
-        [[ "$con_bw" =~ ^\. ]] && con_bw="0$con_bw"
-        printf "| %10s | %7s | %7s | %7s | %7s | %8s | %9s | %8s | %8s |\n" \
-          "$formatted_rate" "$min_lat" "$median_lat" "$p75_lat" "$p95_lat" "$p99_lat" "$formatted_pub_rate" "$pub_bw" "$con_bw"
-      done
-    else
-      # Per-run tables
-      for RUN in $(seq 1 "$NUM_RUNS"); do
-        echo "### Run $RUN of $NUM_RUNS ($SIZE)"
-        echo ""
-        echo "| Rate Limit |     Min |  Median |     P75 |     P95 |      P99 | Pub. Rate |  Pub. BW |  Con. BW |"
-        echo "|-----------:|--------:|--------:|--------:|--------:|---------:|----------:|---------:|---------:|"
-
-        awk -F',' -v run="$RUN" '$1 == run' "$SIZE_CSV" | while IFS=',' read -r run rate min_lat median_lat p75_lat p95_lat p99_lat pub_rate pub_bw con_bw; do
-          formatted_rate=$(format_number "$rate")
-          formatted_pub_rate=$(format_number "$pub_rate")
-          [[ "$pub_bw" =~ ^\. ]] && pub_bw="0$pub_bw"
-          [[ "$con_bw" =~ ^\. ]] && con_bw="0$con_bw"
-          printf "| %10s | %7s | %7s | %7s | %7s | %8s | %9s | %8s | %8s |\n" \
-            "$formatted_rate" "$min_lat" "$median_lat" "$p75_lat" "$p95_lat" "$p99_lat" "$formatted_pub_rate" "$pub_bw" "$con_bw"
-        done
-        echo ""
-      done
-
-      # Summary table (median across runs per rate — robust against single-run spikes)
-      echo "### Summary ($NUM_RUNS runs, $SIZE)"
-      echo ""
-      echo "| Rate Limit |     Min |  Median |     P75 |     P95 |      P99 | Pub. Rate |  Pub. BW |  Con. BW |"
-      echo "|-----------:|--------:|--------:|--------:|--------:|---------:|----------:|---------:|---------:|"
-
-      RATES_STR="${SIZE_RATE_MAP[$SIZE]:-$RATE_LIMITS}"
-      IFS=',' read -ra RATES_THIS_SIZE <<< "$RATES_STR"
-      for RATE in "${RATES_THIS_SIZE[@]}"; do
-        MED_MIN=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$3} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
-        MED_MEDIAN=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$4} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
-        MED_P75=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$5} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
-        MED_P95=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$6} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
-        MED_P99=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$7} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
-        MED_PUB_RATE=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$8} END {asort(vals); m=int(n/2)+1; printf "%d", vals[m]}' "$SIZE_CSV")
-        MED_PUB_BW=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$9} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
-        MED_CON_BW=$(awk -F',' -v r="$RATE" '$2 == r {vals[++n]=$10} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$SIZE_CSV")
-
-        formatted_rate=$(format_number "$RATE")
-        formatted_pub_rate=$(format_number "$MED_PUB_RATE")
-        [[ "$MED_PUB_BW" =~ ^\. ]] && MED_PUB_BW="0$MED_PUB_BW"
-        [[ "$MED_CON_BW" =~ ^\. ]] && MED_CON_BW="0$MED_CON_BW"
-        printf "| %10s | %7s | %7s | %7s | %7s | %8s | %9s | %8s | %8s |\n" \
-          "$formatted_rate" "$MED_MIN" "$MED_MEDIAN" "$MED_P75" "$MED_P95" "$MED_P99" "$formatted_pub_rate" "$MED_PUB_BW" "$MED_CON_BW"
-      done
-    fi
-
-    echo ""
+# Build per_size_rate_limits JSON object
+PSRL_JSON="{"
+if [ -n "$PER_SIZE_RATE_LIMITS" ]; then
+  _FIRST=1
+  IFS='|' read -ra _PSRL_PAIRS <<< "$PER_SIZE_RATE_LIMITS"
+  for _PAIR in "${_PSRL_PAIRS[@]}"; do
+    _SZ="${_PAIR%%:*}"
+    _RT="${_PAIR#*:}"
+    _RT_JSON=$(printf '%s' "$_RT" | tr ',' '\n' | awk 'BEGIN{printf "["} NR>1{printf ","} {printf "%s",$1} END{printf "]"}')
+    [ "$_FIRST" -eq 0 ] && PSRL_JSON="${PSRL_JSON},"
+    PSRL_JSON="${PSRL_JSON}\"${_SZ}\":${_RT_JSON}"
+    _FIRST=0
   done
+fi
+PSRL_JSON="${PSRL_JSON}}"
 
-} > "$OUTPUT_FILE"
+printf '{\n  "instance_type": "%s",\n  "lavinmq_version": "%s",\n  "duration": %s,\n  "producers": 1,\n  "consumers": 1,\n  "runs": %s,\n  "queue": "%s",\n  "sizes": %s,\n  "rate_limits": %s,\n  "per_size_rate_limits": %s\n}' \
+  "$BROKER_INSTANCE_TYPE" \
+  "$LAVINMQ_VERSION" \
+  "$DURATION" \
+  "$NUM_RUNS" \
+  "$QUEUE_NAME" \
+  "$SIZES_JSON" \
+  "$RATE_LIMITS_JSON" \
+  "$PSRL_JSON" \
+  > "$OUTPUT_JSON"
 
-echo "Results saved to: $OUTPUT_FILE"
+echo "Config saved to: $OUTPUT_JSON"
 echo ""
 echo "=========================================="
 echo "Summary:"
 echo "=========================================="
-cat "$OUTPUT_FILE"
+echo "CSV:  $OUTPUT_CSV"
+echo "JSON: $OUTPUT_JSON"
 echo "=========================================="
 
 # Cleanup temp files

--- a/scripts/run_multiple_throughput_tests.sh
+++ b/scripts/run_multiple_throughput_tests.sh
@@ -18,7 +18,8 @@ SIZES="${2:-16,64,256,512,1024}"  # Default sizes if not provided
 DURATION="${3:-120}"  # Default duration 120 seconds if not provided
 BROKER_INSTANCE_TYPE="${4:-unknown}"  # Broker instance type for reporting
 NUM_RUNS="${5:-${BENCHMARK_NUM_RUNS:-1}}"  # Number of runs per size, default 1
-OUTPUT_FILE="/home/ubuntu/throughput_results.md"
+OUTPUT_CSV="/home/ubuntu/throughput_results.csv"
+OUTPUT_JSON="/home/ubuntu/throughput_results.json"
 TEMP_CSV="/tmp/throughput_results.csv"
 QUEUE_NAME="perf-test"
 
@@ -51,12 +52,13 @@ echo "LavinMQ Version: $LAVINMQ_VERSION"
 echo "Message Sizes: $SIZES"
 echo "Test Duration: $DURATION seconds"
 echo "Number of Runs: $NUM_RUNS"
-echo "Output File: $OUTPUT_FILE"
+echo "Output CSV:  $OUTPUT_CSV"
+echo "Output JSON: $OUTPUT_JSON"
 echo "=========================================="
 echo ""
 
 # Initialize CSV temp file
-echo "Run,Size,Pub_Rate,Con_Rate,Pub_BW,Con_BW" > "$TEMP_CSV"
+echo "Run,Size,PubRate,ConRate,PubBW,ConBW" > "$TEMP_CSV"
 
 # Convert comma-separated sizes to array
 IFS=',' read -ra SIZE_ARRAY <<< "$SIZES"
@@ -121,88 +123,32 @@ echo "All tests completed!"
 echo "=========================================="
 echo ""
 
-# Generate markdown table
-echo "Generating markdown summary..."
+# Move temp CSV to final output location
+mv "$TEMP_CSV" "$OUTPUT_CSV"
 
-{
-  echo "# LavinMQ Throughput Test Results"
-  echo ""
-  echo "Test Date: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-  echo "Broker Instance Type: $BROKER_INSTANCE_TYPE"
-  echo "LavinMQ Version: $LAVINMQ_VERSION"
-  echo ""
-  echo "## Results"
-  echo ""
-  echo "- Size: (bytes)"
-  echo "- Average publish/consume rates: (msgs/s)"
-  echo "- Publish/Consume bandwidth: (MiB/s)"
-  echo ""
+echo "Results saved to: $OUTPUT_CSV"
 
-  if [ "$NUM_RUNS" -eq 1 ]; then
-    # Single run: emit the same table format as before
-    echo "|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |"
-    echo "|------:|------------------:|------------------:|------------:|------------:|"
-    tail -n +2 "$TEMP_CSV" | while IFS=',' read -r run size pub_rate con_rate pub_bw con_bw; do
-      formatted_pub=$(format_number "$pub_rate")
-      formatted_con=$(format_number "$con_rate")
-      printf "| %5s | %17s | %17s | %11s | %11s |\n" "$size" "$formatted_pub" "$formatted_con" "$pub_bw" "$con_bw"
-    done
-  else
-    # Multiple runs: one table per run, then a summary table
-    for RUN in $(seq 1 "$NUM_RUNS"); do
-      echo "### Run $RUN of $NUM_RUNS"
-      echo ""
-      echo "|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |"
-      echo "|------:|------------------:|------------------:|------------:|------------:|"
-      grep "^$RUN," "$TEMP_CSV" | while IFS=',' read -r run size pub_rate con_rate pub_bw con_bw; do
-        formatted_pub=$(format_number "$pub_rate")
-        formatted_con=$(format_number "$con_rate")
-        printf "| %5s | %17s | %17s | %11s | %11s |\n" "$size" "$formatted_pub" "$formatted_con" "$pub_bw" "$con_bw"
-      done
-      echo ""
-    done
+# Write JSON config
+echo "Writing JSON config..."
 
-    # Summary table: median publish and consume rate per size (robust against single-run spikes)
-    echo "### Summary (${NUM_RUNS} runs)"
-    echo ""
-    echo "|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |"
-    echo "|------:|------------------:|------------------:|------------:|------------:|"
-    for SIZE in "${SIZE_ARRAY[@]}"; do
-      MED_PUB=$(awk -F',' -v s="$SIZE" '$2 == s {vals[++n]=$3} END {asort(vals); m=int(n/2)+1; printf "%d", vals[m]}' "$TEMP_CSV")
-      MED_CON=$(awk -F',' -v s="$SIZE" '$2 == s {vals[++n]=$4} END {asort(vals); m=int(n/2)+1; printf "%d", vals[m]}' "$TEMP_CSV")
-      MED_PUB_BW=$(awk -F',' -v s="$SIZE" '$2 == s {vals[++n]=$5} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$TEMP_CSV")
-      MED_CON_BW=$(awk -F',' -v s="$SIZE" '$2 == s {vals[++n]=$6} END {asort(vals); m=int(n/2)+1; printf "%.2f", vals[m]}' "$TEMP_CSV")
+SIZES_JSON=$(printf '%s' "$SIZES" | tr ',' '\n' | awk 'BEGIN{printf "["} NR>1{printf ","} {printf "%s",$1} END{printf "]"}')
 
-      printf "| %5s | %17s | %17s | %11s | %11s |\n" \
-        "$SIZE" \
-        "$(format_number "$MED_PUB")" \
-        "$(format_number "$MED_CON")" \
-        "$MED_PUB_BW" \
-        "$MED_CON_BW"
-    done
-  fi
+printf '{\n  "instance_type": "%s",\n  "lavinmq_version": "%s",\n  "duration": %s,\n  "producers": 1,\n  "consumers": 1,\n  "runs": %s,\n  "queue": "%s",\n  "sizes": %s\n}' \
+  "$BROKER_INSTANCE_TYPE" \
+  "$LAVINMQ_VERSION" \
+  "$DURATION" \
+  "$NUM_RUNS" \
+  "$QUEUE_NAME" \
+  "$SIZES_JSON" \
+  > "$OUTPUT_JSON"
 
-  echo ""
-  echo "## Test Configuration"
-  echo ""
-  echo "- Duration: $DURATION seconds (\`-z $DURATION\`)"
-  echo "- Producers: 1 (\`-x 1\`)"
-  echo "- Consumers: 1 (\`-y 1\`)"
-  echo "- Runs per size: $NUM_RUNS"
-  echo "- Message sizes: $SIZES bytes"
-  echo "- Queue: $QUEUE_NAME"
-  echo ""
-} > "$OUTPUT_FILE"
-
-echo "Results saved to: $OUTPUT_FILE"
+echo "Config saved to: $OUTPUT_JSON"
 echo ""
 echo "=========================================="
 echo "Summary:"
 echo "=========================================="
-cat "$OUTPUT_FILE"
+echo "CSV:  $OUTPUT_CSV"
+echo "JSON: $OUTPUT_JSON"
 echo "=========================================="
-
-# Cleanup temp file
-rm -f "$TEMP_CSV"
 
 exit 0


### PR DESCRIPTION
### WHY are these changes introduced?

Markdown was a poor storage format for benchmark results: parsing required fragile regex, aggregation logic (medians) was duplicated between bash and Python. Moving to CSV + JSON separates raw measurements from metadata, lets `aggregate_results.py` compute statistics directly, and makes the data easy to process with standard tools.

Reference: #43

### WHAT is this pull request doing?

The benchmark scripts (run_multiple_latency_tests.sh, run_multiple_throughput_tests.sh) now write two files instead of one markdown file:

- a CSV with one row per run (raw measurements, no pre-aggregated summaries)
- a JSON file with test configuration metadata (instance type, version, duration, sizes, rate limits)

`aggregate_results.py` is updated to read these CSV+JSON pairs and compute medians using statistics.median.

### HOW was this pull request tested?

Small test run: #50

