### PR TITLE
Increase number of inputs for manual workflow runs

### DIFF
--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -10,6 +10,18 @@ on:
         required: false
         type: string
         default: ""
+      num_runs:
+        required: false
+        type: string
+        default: ""
+      message_sizes:
+        required: false
+        type: string
+        default: ""
+      test_duration:
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       lavinmq_version:
@@ -21,6 +33,21 @@ on:
         required: false
         type: string
         default: ""
+      num_runs:
+        description: "Number of runs per scenario (default: 3)."
+        required: false
+        type: string
+        default: "3"
+      message_sizes:
+        description: "JSON array of message sizes in bytes (default: [16, 64, 256, 512, 1024, 4096, 16384, 65536])."
+        required: false
+        type: string
+        default: "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
+      test_duration:
+        description: "Test duration in seconds per run (default: 20)."
+        required: false
+        type: string
+        default: "20"
 
 env:
   TF_VAR_aws_region: "us-east-2"
@@ -28,12 +55,12 @@ env:
   TF_VAR_ubuntu_code_name: "noble"
   TF_VAR_tag_created_by: "github-actions"
   TF_VAR_tag_name: "lavinmq-benchmark-ci"
-  TF_VAR_message_sizes: "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
-  TF_VAR_num_runs: "3"
+  TF_VAR_message_sizes: ${{ inputs.message_sizes || '[16, 64, 256, 512, 1024, 4096, 16384, 65536]' }}
+  TF_VAR_num_runs: ${{ inputs.num_runs || '3' }}
   TF_VAR_broker_volume_size: "20"
   TF_VAR_load_generator_volume_size: "8"
   TF_VAR_lavinmq_version: ${{ inputs.lavinmq_version }}
-  TF_VAR_test_duration: "20"
+  TF_VAR_test_duration: ${{ inputs.test_duration || '20' }}
   TF_VAR_rate_limits: "[10, 100, 1000, 10000, 50000, 100000, 200000, 500000]"
   TF_VAR_per_size_rate_limits: >-
     {"16":[10,100,1000,5000,10000,50000,100000,250000,500000],

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -10,6 +10,18 @@ on:
         required: false
         type: string
         default: ""
+      num_runs:
+        required: false
+        type: string
+        default: ""
+      message_sizes:
+        required: false
+        type: string
+        default: ""
+      test_duration:
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       lavinmq_version:
@@ -21,6 +33,21 @@ on:
         required: false
         type: string
         default: ""
+      num_runs:
+        description: "Number of runs per scenario (default: 3)."
+        required: false
+        type: string
+        default: "3"
+      message_sizes:
+        description: "JSON array of message sizes in bytes (default: [16, 64, 256, 512, 1024, 4096, 16384, 65536])."
+        required: false
+        type: string
+        default: "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
+      test_duration:
+        description: "Test duration in seconds per run (default: 60)."
+        required: false
+        type: string
+        default: "60"
 
 env:
   TF_VAR_aws_region: "us-east-2"
@@ -28,12 +55,12 @@ env:
   TF_VAR_ubuntu_code_name: "noble"
   TF_VAR_tag_created_by: "github-actions"
   TF_VAR_tag_name: "lavinmq-benchmark-ci"
-  TF_VAR_message_sizes: "[16, 64, 256, 512, 1024, 4096, 16384, 65536]"
-  TF_VAR_num_runs: "3"
+  TF_VAR_message_sizes: ${{ inputs.message_sizes || '[16, 64, 256, 512, 1024, 4096, 16384, 65536]' }}
+  TF_VAR_num_runs: ${{ inputs.num_runs || '3' }}
   TF_VAR_broker_volume_size: "20"
   TF_VAR_load_generator_volume_size: "8"
   TF_VAR_lavinmq_version: ${{ inputs.lavinmq_version }}
-  TF_VAR_test_duration: "60"
+  TF_VAR_test_duration: ${{ inputs.test_duration || '60' }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,31 @@ on:
         required: false
         type: string
         default: ""
+      num_runs:
+        description: "Number of runs per scenario. Leave empty to use default (3)."
+        required: false
+        type: string
+        default: ""
+      message_sizes:
+        description: "JSON array of message sizes in bytes. Leave empty to use default ([16, 64, 256, 512, 1024, 4096, 16384, 65536])."
+        required: false
+        type: string
+        default: ""
+      test_duration:
+        description: "Test duration in seconds per run. Leave empty to use per-scenario defaults (latency: 20s, throughput: 60s)."
+        required: false
+        type: string
+        default: ""
+      draft:
+        description: "Open the results PR as a draft."
+        required: false
+        type: boolean
+        default: true
+      pr_title:
+        description: "PR title. Leave empty to auto-generate (\"Benchmark results: vX.Y.Z\")."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -33,6 +58,9 @@ jobs:
     with:
       lavinmq_version: ${{ inputs.lavinmq_version }}
       brokers: ${{ inputs.brokers }}
+      num_runs: ${{ inputs.num_runs }}
+      message_sizes: ${{ inputs.message_sizes }}
+      test_duration: ${{ inputs.test_duration }}
     secrets: inherit
 
   throughput:
@@ -42,6 +70,9 @@ jobs:
     with:
       lavinmq_version: ${{ inputs.lavinmq_version }}
       brokers: ${{ inputs.brokers }}
+      num_runs: ${{ inputs.num_runs }}
+      message_sizes: ${{ inputs.message_sizes }}
+      test_duration: ${{ inputs.test_duration }}
     secrets: inherit
 
   # --------------------------------------------------------------------------
@@ -126,10 +157,10 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           add-paths: results/
-          draft: true # Temporary draft status
+          draft: ${{ inputs.draft }}
           branch: results/v${{ inputs.lavinmq_version }}
           base: main
-          title: "Benchmark results: v${{ inputs.lavinmq_version }}"
+          title: "${{ inputs.pr_title || format('Benchmark results: v{0}', inputs.lavinmq_version) }}"
           commit-message: "Add ${{ inputs.scenarios }} benchmark results for v${{ inputs.lavinmq_version }} [run ${{ github.run_id }}]"
           body: |
             Automated benchmark results for LavinMQ **v${{ inputs.lavinmq_version }}**.


### PR DESCRIPTION
### WHY are these changes introduced?

Instead of temporary change workflow files. Support more inputs to
limit what is benchmarked. Makes it easier to test new workflows and branches.

### WHAT is this pull request doing?

Adds support to change:
- `num_runs`, `message_sizes`, `test_duration` for child workflows
- `draft` pull request with aggregated results, default true
- `pr_title` change title on pull request, default auto generated (results/<lavinmq-version>)

### HOW was this pull request tested?

Workflow run