### PR TITLE
Test inputs

### DIFF
--- a/results/v2.7.0-rc.3/throughput.md
+++ b/results/v2.7.0-rc.3/throughput.md
@@ -1,0 +1,33 @@
+# LavinMQ Throughput Results
+
+## Benchmark Setup
+
+- Network (VPC, internet gateway, subnet, route table, route table associated, ingress rule)
+- Benchmark-broker (AWS instance, public IP)
+- Benchmark-loadgen (AWS instance, public IP)
+
+Load generator -> AMQP-URL (broker private IP) -> Broker
+
+## Table Headers
+
+- **Size**: Message size in bytes
+- **Avg. Publish Rate**: Average publish rate in msgs/s
+- **Avg. Consume Rate**: Average consume rate in msgs/s
+- **Publish BW**: Publish bandwidth in MiB/s
+- **Consume BW**: Consume bandwidth in MiB/s
+
+## AWS Instance Types
+
+Benchmark results for AWS instance types with LavinMQ version v2.7.0-rc.3.
+
+```shell
+lavinmqperf throughput -z 60 -x 1 -y 1 -s <size>
+```
+
+### CPU Optimized
+
+**c8g.large** - 2 vCPU, 4 GiB RAM (ARM-based AWS Graviton4)
+
+|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |
+|------:|------------------:|------------------:|------------:|------------:|
+|    16 |           922,956 |           922,740 |       14.08 |       14.07 |

--- a/results/v2.7.0-rc.3/throughput/c8g-large_throughput.md
+++ b/results/v2.7.0-rc.3/throughput/c8g-large_throughput.md
@@ -1,0 +1,25 @@
+# LavinMQ Throughput Test Results
+
+Test Date: 2026-04-29 10:52:07 UTC
+Broker Instance Type: c8g.large
+LavinMQ Version: 2.7.0-rc.3
+
+## Results
+
+- Size: (bytes)
+- Average publish/consume rates: (msgs/s)
+- Publish/Consume bandwidth: (MiB/s)
+
+|  Size | Avg. Publish Rate | Avg. Consume Rate |  Publish BW |  Consume BW |
+|------:|------------------:|------------------:|------------:|------------:|
+|    16 |           922,956 |           922,740 |       14.08 |       14.07 |
+
+## Test Configuration
+
+- Duration: 60 seconds (`-z 60`)
+- Producers: 1 (`-x 1`)
+- Consumers: 1 (`-y 1`)
+- Runs per size: 1
+- Message sizes: 16 bytes
+- Queue: perf-test
+


### PR DESCRIPTION
Automated benchmark results for LavinMQ **v2.7.0-rc.3**.

Run: [25104614139](https://github.com/cloudamqp/lavinmq-benchmark/actions/runs/25104614139)
Scenarios: `throughput`

Results are in `results/v2.7.0-rc.3/`. Additional scenarios can be added to this PR by triggering new runs with the same version.