### PR TITLE
ix: use cloudamqp/erlang packagecloud repo to install OTP for emqtt-bench

### DIFF
--- a/scripts/install_mqtt_tools.sh
+++ b/scripts/install_mqtt_tools.sh
@@ -19,12 +19,17 @@ retry() {
 
 retry 5 apt-get update -qq > /dev/null
 
-# Install Erlang 27 for emqtt-bench (Ubuntu default is too old; use Erlang Solutions for OTP 27)
-retry 5 curl -fsSL https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb \
-  -o /tmp/erlang-solutions.deb
-dpkg -i /tmp/erlang-solutions.deb
+# Install Erlang for emqtt-bench (OTP 27+ required; use cloudamqp/erlang on packagecloud)
+. /etc/os-release
+mkdir -p /etc/apt/keyrings
+retry 5 curl -fsSL https://packagecloud.io/cloudamqp/erlang/gpgkey \
+  -o /tmp/cloudamqp-erlang.gpg.tmp
+gpg --dearmor < /tmp/cloudamqp-erlang.gpg.tmp > /etc/apt/keyrings/cloudamqp-erlang.gpg
+rm /tmp/cloudamqp-erlang.gpg.tmp
+echo "deb [signed-by=/etc/apt/keyrings/cloudamqp-erlang.gpg] https://packagecloud.io/cloudamqp/erlang/${ID} ${VERSION_CODENAME} main" \
+  > /etc/apt/sources.list.d/cloudamqp-erlang.list
 retry 5 apt-get update -qq > /dev/null
-retry 5 apt-get install -y -qq "esl-erlang=1:27.*" > /dev/null
+retry 5 apt-get install -y -qq esl-erlang > /dev/null
 
 # Install Java for mqttloader
 retry 5 apt-get install default-jre unzip -y -qq > /dev/null

--- a/scripts/install_mqtt_tools.sh
+++ b/scripts/install_mqtt_tools.sh
@@ -19,11 +19,12 @@ retry() {
 
 retry 5 apt-get update -qq > /dev/null
 
-# Install Erlang 27 for emqtt-bench (Ubuntu default is too old)
-retry 5 apt-get install -y -qq software-properties-common > /dev/null
-retry 5 add-apt-repository -y ppa:rabbitmq/rabbitmq-erlang > /dev/null
+# Install Erlang 27 for emqtt-bench (Ubuntu default is too old; use Erlang Solutions for OTP 27)
+retry 5 curl -fsSL https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb \
+  -o /tmp/erlang-solutions.deb
+dpkg -i /tmp/erlang-solutions.deb
 retry 5 apt-get update -qq > /dev/null
-retry 5 apt-get install -y -qq erlang > /dev/null
+retry 5 apt-get install -y -qq "esl-erlang=1:27.*" > /dev/null
 
 # Install Java for mqttloader
 retry 5 apt-get install default-jre unzip -y -qq > /dev/null


### PR DESCRIPTION
### WHY are these changes introduced?

`emqtt-bench` master raised minimum OTP version to 27.2. While the RabbitMQ PPA install OTP 25 on Ubuntu Noble, causing all MQTT benchmark runs to fail.

### WHAT is this pull request doing?

Replaces RabbitMQ PPA Erlang package with cloudamqp/erlang mirror to install latest OTP version.

### HOW was this pull request tested?

https://github.com/cloudamqp/lavinmq-benchmark/actions/runs/25374940510