### PR TITLE
Set specific version for broker and load generator

### DIFF
--- a/.github/workflows/benchmark-commit.yml
+++ b/.github/workflows/benchmark-commit.yml
@@ -197,7 +197,8 @@ jobs:
     if: inputs.scenarios == 'all' || inputs.scenarios == 'latency'
     uses: ./.github/workflows/benchmark-latency.yml
     with:
-      lavinmq_version: ${{ inputs.lavinmq_version }}
+      broker_version: ${{ inputs.lavinmq_version }}
+      load_generator_version: ${{ inputs.lavinmq_version }}
       brokers: ${{ inputs.brokers }}
       num_runs: ${{ inputs.num_runs }}
       message_sizes: ${{ inputs.message_sizes }}
@@ -214,7 +215,8 @@ jobs:
     if: inputs.scenarios == 'all' || inputs.scenarios == 'throughput'
     uses: ./.github/workflows/benchmark-throughput.yml
     with:
-      lavinmq_version: ${{ inputs.lavinmq_version }}
+      broker_version: ${{ inputs.lavinmq_version }}
+      load_generator_version: ${{ inputs.lavinmq_version }}
       brokers: ${{ inputs.brokers }}
       num_runs: ${{ inputs.num_runs }}
       message_sizes: ${{ inputs.message_sizes }}
@@ -231,7 +233,8 @@ jobs:
     if: inputs.scenarios == 'all' || inputs.scenarios == 'mqtt-throughput'
     uses: ./.github/workflows/benchmark-mqtt-throughput.yml
     with:
-      lavinmq_version: ${{ inputs.lavinmq_version }}
+      broker_version: ${{ inputs.lavinmq_version }}
+      load_generator_version: ${{ inputs.lavinmq_version }}
       brokers: ${{ inputs.brokers }}
       num_runs: ${{ inputs.num_runs }}
       message_sizes: ${{ inputs.message_sizes }}

--- a/.github/workflows/benchmark-latency.yml
+++ b/.github/workflows/benchmark-latency.yml
@@ -3,7 +3,11 @@ name: Benchmark – Latency
 on:
   workflow_call:
     inputs:
-      lavinmq_version:
+      broker_version:
+        required: false
+        type: string
+        default: ""
+      load_generator_version:
         required: false
         type: string
         default: ""
@@ -41,10 +45,15 @@ on:
         default: ""
   workflow_dispatch:
     inputs:
-      lavinmq_version:
-        description: "LavinMQ version to benchmark (e.g. 2.7.0-rc.3 or 2.7.0)"
+      broker_version:
+        description: "Broker LavinMQ version to benchmark (e.g. 2.7.0-rc.3 or 2.7.0)"
         required: true
         type: string
+      load_generator_version:
+        description: "Load generator LavinMQ version. Leave empty for latest stable."
+        required: false
+        type: string
+        default: ""
       brokers:
         description: "Comma-separated broker instance types to run (e.g. \"c8g.large\" or \"c8g.large,t4g.micro\"). Leave empty to run all."
         required: false
@@ -76,7 +85,8 @@ env:
   TF_VAR_num_runs: ${{ inputs.num_runs || '3' }}
   TF_VAR_broker_volume_size: "20"
   TF_VAR_load_generator_volume_size: "8"
-  TF_VAR_lavinmq_version: ${{ inputs.lavinmq_version }}
+  TF_VAR_broker_version: ${{ inputs.broker_version }}
+  TF_VAR_load_generator_version: ${{ inputs.load_generator_version }}
   TF_VAR_test_duration: ${{ inputs.test_duration || '20' }}
   TF_VAR_broker_source_repo: ${{ inputs.broker_source_repo }}
   TF_VAR_broker_source_ref: ${{ inputs.broker_source_ref }}

--- a/.github/workflows/benchmark-mqtt-throughput.yml
+++ b/.github/workflows/benchmark-mqtt-throughput.yml
@@ -3,7 +3,11 @@ name: Benchmark – MQTT Throughput
 on:
   workflow_call:
     inputs:
-      lavinmq_version:
+      broker_version:
+        required: false
+        type: string
+        default: ""
+      load_generator_version:
         required: false
         type: string
         default: ""
@@ -41,10 +45,15 @@ on:
         default: ""
   workflow_dispatch:
     inputs:
-      lavinmq_version:
-        description: "LavinMQ version to benchmark (e.g. 2.7.0-rc.3 or 2.7.0)"
+      broker_version:
+        description: "Broker LavinMQ version to benchmark (e.g. 2.7.0-rc.3 or 2.7.0)"
         required: true
         type: string
+      load_generator_version:
+        description: "Load generator LavinMQ version. Leave empty for latest stable."
+        required: false
+        type: string
+        default: ""
       brokers:
         description: "Comma-separated broker instance types to run (e.g. \"c8g.large\" or \"c8g.large,t4g.micro\"). Leave empty to run all."
         required: false
@@ -76,7 +85,8 @@ env:
   TF_VAR_num_runs: ${{ inputs.num_runs || '3' }}
   TF_VAR_broker_volume_size: "20"
   TF_VAR_load_generator_volume_size: "8"
-  TF_VAR_lavinmq_version: ${{ inputs.lavinmq_version }}
+  TF_VAR_broker_version: ${{ inputs.broker_version }}
+  TF_VAR_load_generator_version: ${{ inputs.load_generator_version }}
   TF_VAR_test_duration: ${{ inputs.test_duration || '60' }}
   TF_VAR_broker_source_repo: ${{ inputs.broker_source_repo }}
   TF_VAR_broker_source_ref: ${{ inputs.broker_source_ref }}

--- a/.github/workflows/benchmark-throughput.yml
+++ b/.github/workflows/benchmark-throughput.yml
@@ -3,7 +3,11 @@ name: Benchmark – Throughput
 on:
   workflow_call:
     inputs:
-      lavinmq_version:
+      broker_version:
+        required: false
+        type: string
+        default: ""
+      load_generator_version:
         required: false
         type: string
         default: ""
@@ -41,10 +45,15 @@ on:
         default: ""
   workflow_dispatch:
     inputs:
-      lavinmq_version:
-        description: "LavinMQ version to benchmark (e.g. 2.7.0-rc.3 or 2.7.0)"
+      broker_version:
+        description: "Broker LavinMQ version to benchmark (e.g. 2.7.0-rc.3 or 2.7.0)"
         required: true
         type: string
+      load_generator_version:
+        description: "Load generator LavinMQ version. Leave empty for latest stable."
+        required: false
+        type: string
+        default: ""
       brokers:
         description: "Comma-separated broker instance types to run (e.g. \"c8g.large\" or \"c8g.large,t4g.micro\"). Leave empty to run all."
         required: false
@@ -76,7 +85,8 @@ env:
   TF_VAR_num_runs: ${{ inputs.num_runs || '3' }}
   TF_VAR_broker_volume_size: "20"
   TF_VAR_load_generator_volume_size: "8"
-  TF_VAR_lavinmq_version: ${{ inputs.lavinmq_version }}
+  TF_VAR_broker_version: ${{ inputs.broker_version }}
+  TF_VAR_load_generator_version: ${{ inputs.load_generator_version }}
   TF_VAR_test_duration: ${{ inputs.test_duration || '60' }}
   TF_VAR_broker_source_repo: ${{ inputs.broker_source_repo }}
   TF_VAR_broker_source_ref: ${{ inputs.broker_source_ref }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,10 +3,15 @@ name: Benchmark
 on:
   workflow_dispatch:
     inputs:
-      lavinmq_version:
-        description: "LavinMQ version to benchmark (e.g. 2.7.0-rc.3 or 2.7.0)"
+      broker_version:
+        description: "Broker LavinMQ version to benchmark (e.g. 2.7.0-rc.3 or 2.7.0)"
         required: true
         type: string
+      load_generator_version:
+        description: "Load generator LavinMQ version. Leave empty for latest stable."
+        required: false
+        type: string
+        default: ""
       scenarios:
         description: "Which scenarios to run"
         required: true
@@ -57,7 +62,7 @@ permissions:
 # the results/v<ver> branch, so the worst case is one redundant run, never a
 # duplicate PR.
 concurrency:
-  group: benchmark-${{ inputs.lavinmq_version }}
+  group: benchmark-${{ inputs.broker_version }}
   cancel-in-progress: false
 
 jobs:
@@ -66,7 +71,8 @@ jobs:
     if: inputs.scenarios == 'all' || inputs.scenarios == 'latency'
     uses: ./.github/workflows/benchmark-latency.yml
     with:
-      lavinmq_version: ${{ inputs.lavinmq_version }}
+      broker_version: ${{ inputs.broker_version }}
+      load_generator_version: ${{ inputs.load_generator_version }}
       brokers: ${{ inputs.brokers }}
       num_runs: ${{ inputs.num_runs }}
       message_sizes: ${{ inputs.message_sizes }}
@@ -78,7 +84,8 @@ jobs:
     if: inputs.scenarios == 'all' || inputs.scenarios == 'throughput'
     uses: ./.github/workflows/benchmark-throughput.yml
     with:
-      lavinmq_version: ${{ inputs.lavinmq_version }}
+      broker_version: ${{ inputs.broker_version }}
+      load_generator_version: ${{ inputs.load_generator_version }}
       brokers: ${{ inputs.brokers }}
       num_runs: ${{ inputs.num_runs }}
       message_sizes: ${{ inputs.message_sizes }}
@@ -90,7 +97,8 @@ jobs:
     if: inputs.scenarios == 'all' || inputs.scenarios == 'mqtt-throughput'
     uses: ./.github/workflows/benchmark-mqtt-throughput.yml
     with:
-      lavinmq_version: ${{ inputs.lavinmq_version }}
+      broker_version: ${{ inputs.broker_version }}
+      load_generator_version: ${{ inputs.load_generator_version }}
       brokers: ${{ inputs.brokers }}
       num_runs: ${{ inputs.num_runs }}
       message_sizes: ${{ inputs.message_sizes }}
@@ -158,7 +166,7 @@ jobs:
       - name: Compute results path
         if: env.has_results == 'true'
         run: |
-          VERSION="${{ inputs.lavinmq_version }}"
+          VERSION="${{ inputs.broker_version }}"
           if echo "$VERSION" | grep -qE '-(rc|beta)\.'; then
             echo "RESULTS_SUBDIR=pre-release/v${VERSION}" >> "$GITHUB_ENV"
           else
@@ -177,7 +185,7 @@ jobs:
         if: env.has_results == 'true'
         run: |
           python scripts/aggregate_results.py \
-            --version "${{ inputs.lavinmq_version }}" \
+            --version "${{ inputs.broker_version }}" \
             --latency-dir         raw-results/latency \
             --throughput-dir      raw-results/throughput \
             --mqtt-throughput-dir raw-results/mqtt-throughput \
@@ -202,10 +210,10 @@ jobs:
           draft: ${{ inputs.draft }}
           branch: results/${{ env.RESULTS_SUBDIR }}
           base: main
-          title: "${{ inputs.pr_title || format('Benchmark results: v{0}', inputs.lavinmq_version) }}"
-          commit-message: "Add ${{ inputs.scenarios }} benchmark results for v${{ inputs.lavinmq_version }} [run ${{ github.run_id }}]"
+          title: "${{ inputs.pr_title || format('Benchmark results: v{0}', inputs.broker_version) }}"
+          commit-message: "Add ${{ inputs.scenarios }} benchmark results for v${{ inputs.broker_version }} [run ${{ github.run_id }}]"
           body: |
-            Automated benchmark results for LavinMQ **v${{ inputs.lavinmq_version }}**.
+            Automated benchmark results for LavinMQ **v${{ inputs.broker_version }}**.
 
             Run: [${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
             Scenarios: `${{ inputs.scenarios }}`
@@ -224,13 +232,13 @@ jobs:
     steps:
       - name: Write job summary
         run: |
-          VERSION="v${{ inputs.lavinmq_version }}"
+          VERSION="v${{ inputs.broker_version }}"
           cat >> "$GITHUB_STEP_SUMMARY" << EOF
           ## Benchmark run: ${VERSION}
 
           | | Result |
           |---|---|
-          | LavinMQ version | \`${VERSION}\` |
+          | Broker version | \`${VERSION}\` |
           | Scenarios | \`${{ inputs.scenarios }}\` |
           | Latency jobs | ${{ needs.latency.result || 'skipped' }} |
           | Throughput jobs | ${{ needs.throughput.result || 'skipped' }} |

--- a/.github/workflows/poll-lavinmq-releases.yml
+++ b/.github/workflows/poll-lavinmq-releases.yml
@@ -79,5 +79,5 @@ jobs:
 
           while IFS= read -r v; do
             echo "→ dispatching benchmark for v${v}"
-            gh workflow run benchmark.yml -f lavinmq_version="$v" -f scenarios=all
+            gh workflow run benchmark.yml -f broker_version="$v" -f load_generator_version="$v" -f scenarios=all
           done < new.txt

--- a/scenarios/aws/mqtt_throughput/README.md
+++ b/scenarios/aws/mqtt_throughput/README.md
@@ -71,7 +71,8 @@ TF_VAR_ubuntu_code_name="noble"       # Ubuntu version
 # Benchmark server
 TF_VAR_broker_volume_size=20          # Root disk size in GB
 TF_VAR_load_generator_volume_size=8   # Root disk size in GB
-TF_VAR_lavinmq_version=""             # Empty = latest, or specify a version
+TF_VAR_broker_version=""              # Empty = latest stable, or specify version (e.g. 2.7.0-rc.3)
+TF_VAR_load_generator_version=""      # Empty = latest stable, or specify version
 
 # Test configuration
 TF_VAR_message_sizes=[16, 64, 256, 512, 1024]  # Message sizes in bytes

--- a/scenarios/aws/mqtt_throughput/main.tf
+++ b/scenarios/aws/mqtt_throughput/main.tf
@@ -48,7 +48,7 @@ module "broker" {
 
   # Install lavinmq
   install_crystal     = true
-  lavinmq_version     = var.lavinmq_version
+  lavinmq_version     = var.broker_version
   install_lavinmq     = true
   configure_lavinmq   = true
   create_lavinmq_user = true
@@ -70,7 +70,7 @@ module "load_generator" {
 
   # Install lavinmq (for lavinmqperf, not used here but keeps instance consistent) # TODO
   install_crystal = true
-  lavinmq_version = ""
+  lavinmq_version = var.load_generator_version
   install_lavinmq = true
   stop_lavinmq    = true
   source_repo     = var.load_generator_source_repo
@@ -101,7 +101,8 @@ resource "terraform_data" "mqtt_throughput_tests" {
     join(",", var.message_sizes),
     var.test_duration,
     var.broker_instance_type,
-    var.lavinmq_version,
+    var.broker_version,
+    var.load_generator_version,
     var.num_runs,
     var.broker_source_ref,
     var.load_generator_source_ref,

--- a/scenarios/aws/mqtt_throughput/variables.tf
+++ b/scenarios/aws/mqtt_throughput/variables.tf
@@ -41,7 +41,12 @@ variable "ssh_key_name" {
 
 # Benchmark servers
 
-variable "lavinmq_version" {
+variable "broker_version" {
+  type    = string
+  default = ""
+}
+
+variable "load_generator_version" {
   type    = string
   default = ""
 }

--- a/scenarios/aws/multiple_run_latency/README.md
+++ b/scenarios/aws/multiple_run_latency/README.md
@@ -73,7 +73,8 @@ TF_VAR_ubuntu_code_name = "noble"                                            # U
 # Benchmark server
 TF_VAR_broker_volume_size = 8                                               # Root disk size in GB
 TF_VAR_load_generator_volume_size = 8                                       # Root disk size in GB
-TF_VAR_lavinmq_version = ""                                                 # Empty = latest, or specify version
+TF_VAR_broker_version = ""                                                  # Empty = latest stable, or specify version (e.g. 2.7.0-rc.3)
+TF_VAR_load_generator_version = ""                                          # Empty = latest stable, or specify version
 
 # Test configuration
 TF_VAR_message_sizes = [16, 64, 256, 512, 1024, 4096, 16384, 65536]        # Message sizes in bytes

--- a/scenarios/aws/multiple_run_latency/main.tf
+++ b/scenarios/aws/multiple_run_latency/main.tf
@@ -48,7 +48,7 @@ module "broker" {
 
   # Install lavinmq
   install_crystal     = true
-  lavinmq_version     = var.lavinmq_version
+  lavinmq_version     = var.broker_version
   install_lavinmq     = true
   configure_lavinmq   = true
   create_lavinmq_user = true
@@ -70,7 +70,7 @@ module "load_generator" {
 
   # Install lavinmq
   install_crystal = true
-  lavinmq_version = "" // Use latest version
+  lavinmq_version = var.load_generator_version
   install_lavinmq = true
   stop_lavinmq    = true
   source_repo     = var.load_generator_source_repo
@@ -86,14 +86,15 @@ resource "terraform_data" "multiple_latency_tests" {
     agent = true
   }
 
-  # Trigger replacement when message sizes, rate limits, test duration, broker instance type, lavinmq version, or num_runs changes
+  # Trigger replacement when message sizes, rate limits, test duration, broker instance type, broker/load_generator version, or num_runs changes
   triggers_replace = [
     join(",", var.message_sizes),
     join(",", var.rate_limits),
     join("|", [for s, r in var.per_size_rate_limits : "${s}:${join(",", r)}"]),
     var.test_duration,
     var.broker_instance_type,
-    var.lavinmq_version,
+    var.broker_version,
+    var.load_generator_version,
     var.num_runs,
     var.broker_source_ref,
     var.load_generator_source_ref,

--- a/scenarios/aws/multiple_run_latency/variables.tf
+++ b/scenarios/aws/multiple_run_latency/variables.tf
@@ -41,7 +41,12 @@ variable "ssh_key_name" {
 
 # Benchmark servers
 
-variable "lavinmq_version" {
+variable "broker_version" {
+  type    = string
+  default = ""
+}
+
+variable "load_generator_version" {
   type    = string
   default = ""
 }

--- a/scenarios/aws/multiple_run_throughput/README.md
+++ b/scenarios/aws/multiple_run_throughput/README.md
@@ -72,7 +72,8 @@ TF_VAR_ubuntu_code_name = "noble"   # Ubuntu version
 # Benchmark server
 TF_VAR_broker_volume_size = 8          # Root disk size in GB
 TF_VAR_load_generator_volume_size = 8  # Root disk size in GB
-TF_VAR_lavinmq_version = ""            # Empty = latest, or specify version
+TF_VAR_broker_version = ""             # Empty = latest stable, or specify version (e.g. 2.7.0-rc.3)
+TF_VAR_load_generator_version = ""     # Empty = latest stable, or specify version
 
 # Test configuration
 TF_VAR_message_sizes = [16, 64, 256, 512, 1024, 4096, 16384, 65536]  # Message sizes in bytes

--- a/scenarios/aws/multiple_run_throughput/main.tf
+++ b/scenarios/aws/multiple_run_throughput/main.tf
@@ -48,7 +48,7 @@ module "broker" {
 
   # Install lavinmq
   install_crystal     = true
-  lavinmq_version     = var.lavinmq_version
+  lavinmq_version     = var.broker_version
   install_lavinmq     = true
   configure_lavinmq   = true
   create_lavinmq_user = true
@@ -70,7 +70,7 @@ module "load_generator" {
 
   # Install lavinmq
   install_crystal = true
-  lavinmq_version = "" // Use latest version
+  lavinmq_version = var.load_generator_version
   install_lavinmq = true
   stop_lavinmq    = true
   source_repo     = var.load_generator_source_repo
@@ -86,12 +86,13 @@ resource "terraform_data" "multiple_throughput_tests" {
     agent = true
   }
 
-  # Trigger replacement when message sizes, test duration, broker instance type, lavinmq version, or num_runs changes
+  # Trigger replacement when message sizes, test duration, broker instance type, broker/load_generator version, or num_runs changes
   triggers_replace = [
     join(",", var.message_sizes),
     var.test_duration,
     var.broker_instance_type,
-    var.lavinmq_version,
+    var.broker_version,
+    var.load_generator_version,
     var.num_runs,
     var.broker_source_ref,
     var.load_generator_source_ref,

--- a/scenarios/aws/multiple_run_throughput/variables.tf
+++ b/scenarios/aws/multiple_run_throughput/variables.tf
@@ -41,7 +41,12 @@ variable "ssh_key_name" {
 
 # Benchmark servers
 
-variable "lavinmq_version" {
+variable "broker_version" {
+  type    = string
+  default = ""
+}
+
+variable "load_generator_version" {
   type    = string
   default = ""
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Broker picked up v2.9.1-rc.1 prelease while load generator use latest stable (v2.8.1).

### WHAT is this pull request doing?

Set two different LavinMQ versions, one for broker and one for load generator.
Default to latest if non set.

### HOW was this pull request tested?

Not tested.