### PR TITLE
Automated triggered benchmark will make ready PR if successful

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -207,7 +207,7 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           add-paths: results/
-          draft: ${{ inputs.draft }}
+          draft: ${{ inputs.draft || needs.latency.result == 'failure' || needs.throughput.result == 'failure' || needs.mqtt_throughput.result == 'failure' }}
           branch: results/${{ env.RESULTS_SUBDIR }}
           base: main
           title: "${{ inputs.pr_title || format('Benchmark results: v{0}', inputs.broker_version) }}"
@@ -219,6 +219,19 @@ jobs:
             Scenarios: `${{ inputs.scenarios }}`
 
             Results are in `results/${{ env.RESULTS_SUBDIR }}/`. Additional scenarios can be added to this PR by triggering new runs with the same version.
+
+      - name: Mark PR ready for review
+        if: |
+          env.has_results == 'true' &&
+          !inputs.draft &&
+          needs.latency.result != 'failure' &&
+          needs.throughput.result != 'failure' &&
+          needs.mqtt_throughput.result != 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          gh pr ready "results/${{ env.RESULTS_SUBDIR }}" \
+            --repo "${{ github.repository }}" 2>/dev/null || true
 
   # --------------------------------------------------------------------------
   # SUMMARY

--- a/.github/workflows/poll-lavinmq-releases.yml
+++ b/.github/workflows/poll-lavinmq-releases.yml
@@ -79,5 +79,5 @@ jobs:
 
           while IFS= read -r v; do
             echo "→ dispatching benchmark for v${v}"
-            gh workflow run benchmark.yml -f broker_version="$v" -f load_generator_version="$v" -f scenarios=all
+            gh workflow run benchmark.yml -f broker_version="$v" -f load_generator_version="$v" -f scenarios=all -f draft=false
           done < new.txt


### PR DESCRIPTION
### WHY are these changes introduced?

We poll for new LavinMQ release and then start the benchmark workflow for all scenarios.
The PR created will by default set as draft.

### WHAT is this pull request doing?

Make the PR created ready if all scenarios in benchmark is successful, while set to draft in any scenario fails.
Keep default draft when a benchmark run is started manually.

### HOW was this pull request tested?

Not tested.